### PR TITLE
Update to Netty 5.0.0.Alpha2-SNAPSHOT

### DIFF
--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthRequest.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthRequest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.util.CharsetUtil;
 
 import java.nio.charset.CharsetEncoder;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthRequestDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthResponse.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthResponse.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 
 import static java.util.Objects.requireNonNull;
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthResponseDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdRequest.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdRequest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.NetUtil;
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdRequestDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.util.NetUtil;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdResponse.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdResponse.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.NetUtil;
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdResponseDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.util.NetUtil;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCommonUtils.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCommonUtils.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.internal.StringUtil;
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitRequest.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitRequest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 
 import java.util.Collections;
 import java.util.List;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitRequestDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitResponse.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitResponse.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 
 import static java.util.Objects.requireNonNull;
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitResponseDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksMessage.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksMessage.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 
 import static java.util.Objects.requireNonNull;
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksMessageEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksMessageEncoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/UnknownSocksRequest.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/UnknownSocksRequest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 
 /**
  * An unknown socks request.

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/UnknownSocksResponse.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/UnknownSocksResponse.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 
 /**
  * An unknown socks response.

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/SocksPortUnificationServerHandler.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/SocksPortUnificationServerHandler.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.handler.codec.ByteToMessageDecoder;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ClientDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ClientDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v4;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ClientEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ClientEncoder.java
@@ -15,8 +15,8 @@
  */
 package io.netty.contrib.handler.codec.socksx.v4;
 
-import io.netty5.buffer.ByteBuf;
-import io.netty5.buffer.ByteBufUtil;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ServerDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ServerDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v4;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ServerEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ServerEncoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v4;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5AddressDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5AddressDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.handler.codec.DecoderException;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.NetUtil;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5AddressEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5AddressEncoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.handler.codec.EncoderException;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.NetUtil;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5ClientEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5ClientEncoder.java
@@ -15,8 +15,8 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.ByteBuf;
-import io.netty5.buffer.ByteBufUtil;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.EncoderException;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5CommandRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5CommandRequestDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5CommandResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5CommandResponseDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5InitialRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5InitialRequestDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5InitialResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5InitialResponseDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5PasswordAuthRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5PasswordAuthRequestDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5PasswordAuthResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5PasswordAuthResponseDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5ServerEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5ServerEncoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.EncoderException;

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksAuthRequestDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksAuthRequestDecoderTest.java
@@ -15,8 +15,8 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.ByteBuf;
-import io.netty5.buffer.Unpooled;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
 

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCmdRequestTest.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCmdRequestTest.java
@@ -15,8 +15,8 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.ByteBuf;
-import io.netty5.buffer.Unpooled;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty5.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCmdResponseTest.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCmdResponseTest.java
@@ -15,8 +15,8 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.ByteBuf;
-import io.netty5.buffer.Unpooled;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty5.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCommonTestUtils.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCommonTestUtils.java
@@ -15,8 +15,8 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.ByteBuf;
-import io.netty5.buffer.Unpooled;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty5.channel.embedded.EmbeddedChannel;
 
 final class SocksCommonTestUtils {

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socksx/v5/DefaultSocks5CommandResponseTest.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socksx/v5/DefaultSocks5CommandResponseTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socksx/v5/Socks5CommonTestUtils.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socksx/v5/Socks5CommonTestUtils.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.channel.embedded.EmbeddedChannel;
 
 final class Socks5CommonTestUtils {

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socksx/v5/Socks5InitialRequestDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socksx/v5/Socks5InitialRequestDecoderTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.Unpooled;
+import io.netty.buffer.Unpooled;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.DecoderResult;
 import org.junit.jupiter.api.Test;

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/RelayHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/RelayHandler.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.example.socksproxy;
 
-import io.netty5.buffer.Unpooled;
+import io.netty.buffer.Unpooled;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/SocksServerUtils.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/SocksServerUtils.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.example.socksproxy;
 
-import io.netty5.buffer.Unpooled;
+import io.netty.buffer.Unpooled;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelFutureListeners;
 

--- a/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/HttpProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/HttpProxyHandler.java
@@ -38,7 +38,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 
-import static io.netty5.handler.codec.ByteBufToBufferHandler.BYTEBUF_TO_BUFFER_HANDLER;
+import static io.netty5.handler.adaptor.BufferConversionHandler.byteBufToBuffer;
 import static java.util.Objects.requireNonNull;
 
 public final class HttpProxyHandler extends ProxyHandler {
@@ -134,7 +134,7 @@ public final class HttpProxyHandler extends ProxyHandler {
     protected void addCodec(ChannelHandlerContext ctx) throws Exception {
         ChannelPipeline p = ctx.pipeline();
         String name = ctx.name();
-        p.addBefore(name, null, BYTEBUF_TO_BUFFER_HANDLER);
+        p.addBefore(name, null, byteBufToBuffer());
         p.addBefore(name, null, codecWrapper);
     }
 

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/HttpProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/HttpProxyServer.java
@@ -38,7 +38,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
-import static io.netty5.handler.codec.ByteBufToBufferHandler.BYTEBUF_TO_BUFFER_HANDLER;
+import static io.netty5.handler.adaptor.BufferConversionHandler.byteBufToBuffer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class HttpProxyServer extends ProxyServer {
@@ -57,13 +57,13 @@ final class HttpProxyServer extends ProxyServer {
         ChannelPipeline p = ch.pipeline();
         switch (testMode) {
         case INTERMEDIARY:
-            p.addLast(BYTEBUF_TO_BUFFER_HANDLER);
+            p.addLast(byteBufToBuffer());
             p.addLast(new HttpServerCodec());
             p.addLast(new HttpObjectAggregator<DefaultHttpContent>(1));
             p.addLast(new HttpIntermediaryHandler());
             break;
         case TERMINAL:
-            p.addLast(BYTEBUF_TO_BUFFER_HANDLER);
+            p.addLast(byteBufToBuffer());
             p.addLast(new HttpServerCodec());
             p.addLast(new HttpObjectAggregator<DefaultHttpContent>(1));
             p.addLast(new HttpTerminalHandler());

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/HttpProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/HttpProxyServer.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.proxy;
 
-import io.netty5.buffer.Unpooled;
+import io.netty.buffer.Unpooled;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.socket.SocketChannel;

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyHandlerTest.java
@@ -16,9 +16,9 @@
 package io.netty.contrib.handler.proxy;
 
 import io.netty5.bootstrap.Bootstrap;
-import io.netty5.buffer.ByteBuf;
-import io.netty5.buffer.PooledByteBufAllocator;
-import io.netty5.buffer.Unpooled;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.Unpooled;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyServer.java
@@ -17,8 +17,8 @@ package io.netty.contrib.handler.proxy;
 
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
-import io.netty5.buffer.ByteBuf;
-import io.netty5.buffer.Unpooled;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelFutureListeners;
 import io.netty5.channel.ChannelHandler;

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/Socks4ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/Socks4ProxyServer.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.proxy;
 
-import io.netty5.buffer.Unpooled;
+import io.netty.buffer.Unpooled;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.socket.SocketChannel;

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/Socks5ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/Socks5ProxyServer.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.proxy;
 
-import io.netty5.buffer.Unpooled;
+import io.netty.buffer.Unpooled;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.socket.SocketChannel;

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
   </developers>
 
   <properties>
-    <netty.version>5.0.1.Alpha1-SNAPSHOT</netty.version>
+    <netty.version>5.0.0.Alpha2-SNAPSHOT</netty.version>
     <netty.build.version>29</netty.build.version>
     <project.scm.id>github</project.scm.id>
     <release.gpg.keyname />

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
   </developers>
 
   <properties>
-    <netty.version>5.0.0.Final-SNAPSHOT</netty.version>
+    <netty.version>5.0.1.Alpha1-SNAPSHOT</netty.version>
     <netty.build.version>29</netty.build.version>
     <project.scm.id>github</project.scm.id>
     <release.gpg.keyname />


### PR DESCRIPTION
Motivation:

Use the latest changes from Netty 5 snapshot

Modifications:

- Update to Netty 5.0.0.Alpha2-SNAPSHOT
- Use ByteBuf from Netty 4

Result:

Use the latest changes from Netty 5 snapshot