### PR TITLE
Port socks-proxy to Buffer API

### DIFF
--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthRequest.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthRequest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.util.CharsetUtil;
 
 import java.nio.charset.CharsetEncoder;
@@ -72,11 +72,11 @@ public final class SocksAuthRequest extends SocksRequest {
     }
 
     @Override
-    public void encodeAsByteBuf(ByteBuf byteBuf) {
+    public void encodeAsByteBuf(Buffer byteBuf) {
         byteBuf.writeByte(SUBNEGOTIATION_VERSION.byteValue());
-        byteBuf.writeByte(username.length());
+        byteBuf.writeByte((byte) username.length());
         byteBuf.writeCharSequence(username, CharsetUtil.US_ASCII);
-        byteBuf.writeByte(password.length());
+        byteBuf.writeByte((byte) password.length());
         byteBuf.writeCharSequence(password, CharsetUtil.US_ASCII);
     }
 }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthRequest.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthRequest.java
@@ -72,11 +72,11 @@ public final class SocksAuthRequest extends SocksRequest {
     }
 
     @Override
-    public void encodeAsByteBuf(Buffer byteBuf) {
-        byteBuf.writeByte(SUBNEGOTIATION_VERSION.byteValue());
-        byteBuf.writeByte((byte) username.length());
-        byteBuf.writeCharSequence(username, CharsetUtil.US_ASCII);
-        byteBuf.writeByte((byte) password.length());
-        byteBuf.writeCharSequence(password, CharsetUtil.US_ASCII);
+    public void encodeAsBuffer(Buffer buffer) {
+        buffer.writeByte(SUBNEGOTIATION_VERSION.byteValue());
+        buffer.writeByte((byte) username.length());
+        buffer.writeCharSequence(username, CharsetUtil.US_ASCII);
+        buffer.writeByte((byte) password.length());
+        buffer.writeCharSequence(password, CharsetUtil.US_ASCII);
     }
 }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthRequestDecoder.java
@@ -35,40 +35,40 @@ public class SocksAuthRequestDecoder extends ByteToMessageDecoderForBuffer {
     private String username;
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, Buffer byteBuf) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, Buffer buffer) throws Exception {
         switch (state) {
             case CHECK_PROTOCOL_VERSION: {
-                if (byteBuf.readableBytes() < 1) {
+                if (buffer.readableBytes() < 1) {
                     return;
                 }
-                if (byteBuf.readByte() != SocksSubnegotiationVersion.AUTH_PASSWORD.byteValue()) {
+                if (buffer.readByte() != SocksSubnegotiationVersion.AUTH_PASSWORD.byteValue()) {
                     ctx.fireChannelRead(SocksCommonUtils.UNKNOWN_SOCKS_REQUEST);
                     break;
                 }
                 state = State.READ_USERNAME;
             }
             case READ_USERNAME: {
-                if (byteBuf.readableBytes() < 1) {
+                if (buffer.readableBytes() < 1) {
                     return;
                 }
-                int fieldLength = byteBuf.getByte(byteBuf.readerOffset());
-                if (byteBuf.readableBytes() < 1 + fieldLength) {
+                int fieldLength = buffer.getByte(buffer.readerOffset());
+                if (buffer.readableBytes() < 1 + fieldLength) {
                     return;
                 }
-                byteBuf.skipReadable(1);
-                username = byteBuf.readCharSequence(fieldLength, CharsetUtil.US_ASCII).toString();
+                buffer.skipReadable(1);
+                username = buffer.readCharSequence(fieldLength, CharsetUtil.US_ASCII).toString();
                 state = State.READ_PASSWORD;
             }
             case READ_PASSWORD: {
-                if (byteBuf.readableBytes() < 1) {
+                if (buffer.readableBytes() < 1) {
                     return;
                 }
-                int fieldLength = byteBuf.getByte(byteBuf.readerOffset());
-                if (byteBuf.readableBytes() < 1 + fieldLength) {
+                int fieldLength = buffer.getByte(buffer.readerOffset());
+                if (buffer.readableBytes() < 1 + fieldLength) {
                     return;
                 }
-                byteBuf.skipReadable(1);
-                String password = byteBuf.readCharSequence(fieldLength, CharsetUtil.US_ASCII).toString();
+                buffer.skipReadable(1);
+                String password = buffer.readCharSequence(fieldLength, CharsetUtil.US_ASCII).toString();
                 ctx.fireChannelRead(new SocksAuthRequest(username, password));
                 break;
             }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthResponse.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthResponse.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 
 import static java.util.Objects.requireNonNull;
 
@@ -45,7 +45,7 @@ public final class SocksAuthResponse extends SocksResponse {
     }
 
     @Override
-    public void encodeAsByteBuf(ByteBuf byteBuf) {
+    public void encodeAsByteBuf(Buffer byteBuf) {
         byteBuf.writeByte(SUBNEGOTIATION_VERSION.byteValue());
         byteBuf.writeByte(authStatus.byteValue());
     }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthResponse.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthResponse.java
@@ -45,8 +45,8 @@ public final class SocksAuthResponse extends SocksResponse {
     }
 
     @Override
-    public void encodeAsByteBuf(Buffer byteBuf) {
-        byteBuf.writeByte(SUBNEGOTIATION_VERSION.byteValue());
-        byteBuf.writeByte(authStatus.byteValue());
+    public void encodeAsBuffer(Buffer buffer) {
+        buffer.writeByte(SUBNEGOTIATION_VERSION.byteValue());
+        buffer.writeByte(authStatus.byteValue());
     }
 }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthResponseDecoder.java
@@ -33,24 +33,24 @@ public class SocksAuthResponseDecoder extends ByteToMessageDecoderForBuffer {
     private State state = State.CHECK_PROTOCOL_VERSION;
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, Buffer byteBuf)
+    protected void decode(ChannelHandlerContext ctx, Buffer buffer)
             throws Exception {
         switch (state) {
             case CHECK_PROTOCOL_VERSION: {
-                if (byteBuf.readableBytes() < 1) {
+                if (buffer.readableBytes() < 1) {
                     return;
                 }
-                if (byteBuf.readByte() != SocksSubnegotiationVersion.AUTH_PASSWORD.byteValue()) {
+                if (buffer.readByte() != SocksSubnegotiationVersion.AUTH_PASSWORD.byteValue()) {
                     ctx.fireChannelRead(SocksCommonUtils.UNKNOWN_SOCKS_RESPONSE);
                     break;
                 }
                 state = State.READ_AUTH_RESPONSE;
             }
             case READ_AUTH_RESPONSE: {
-                if (byteBuf.readableBytes() < 1) {
+                if (buffer.readableBytes() < 1) {
                     return;
                 }
-                SocksAuthStatus authStatus = SocksAuthStatus.valueOf(byteBuf.readByte());
+                SocksAuthStatus authStatus = SocksAuthStatus.valueOf(buffer.readByte());
                 ctx.fireChannelRead(new SocksAuthResponse(authStatus));
                 break;
             }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthResponseDecoder.java
@@ -15,15 +15,15 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoder;
+import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
 
 /**
- * Decodes {@link ByteBuf}s into {@link SocksAuthResponse}.
+ * Decodes {@link Buffer}s into {@link SocksAuthResponse}.
  * Before returning SocksResponse decoder removes itself from pipeline.
  */
-public class SocksAuthResponseDecoder extends ByteToMessageDecoder {
+public class SocksAuthResponseDecoder extends ByteToMessageDecoderForBuffer {
 
     private enum State {
         CHECK_PROTOCOL_VERSION,
@@ -33,7 +33,7 @@ public class SocksAuthResponseDecoder extends ByteToMessageDecoder {
     private State state = State.CHECK_PROTOCOL_VERSION;
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, ByteBuf byteBuf)
+    protected void decode(ChannelHandlerContext ctx, Buffer byteBuf)
             throws Exception {
         switch (state) {
             case CHECK_PROTOCOL_VERSION: {

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdRequest.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdRequest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.NetUtil;
 
@@ -107,23 +107,23 @@ public final class SocksCmdRequest extends SocksRequest {
     }
 
     @Override
-    public void encodeAsByteBuf(ByteBuf byteBuf) {
+    public void encodeAsByteBuf(Buffer byteBuf) {
         byteBuf.writeByte(protocolVersion().byteValue());
         byteBuf.writeByte(cmdType.byteValue());
-        byteBuf.writeByte(0x00);
+        byteBuf.writeByte((byte) 0x00);
         byteBuf.writeByte(addressType.byteValue());
         switch (addressType) {
             case IPv4:
             case IPv6: {
                 byteBuf.writeBytes(NetUtil.createByteArrayFromIpAddressString(host));
-                byteBuf.writeShort(port);
+                byteBuf.writeShort((short) port);
                 break;
             }
 
             case DOMAIN: {
-                byteBuf.writeByte(host.length());
+                byteBuf.writeByte((byte) host.length());
                 byteBuf.writeCharSequence(host, CharsetUtil.US_ASCII);
-                byteBuf.writeShort(port);
+                byteBuf.writeShort((short) port);
                 break;
             }
         }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdRequest.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdRequest.java
@@ -107,23 +107,23 @@ public final class SocksCmdRequest extends SocksRequest {
     }
 
     @Override
-    public void encodeAsByteBuf(Buffer byteBuf) {
-        byteBuf.writeByte(protocolVersion().byteValue());
-        byteBuf.writeByte(cmdType.byteValue());
-        byteBuf.writeByte((byte) 0x00);
-        byteBuf.writeByte(addressType.byteValue());
+    public void encodeAsBuffer(Buffer buffer) {
+        buffer.writeByte(protocolVersion().byteValue());
+        buffer.writeByte(cmdType.byteValue());
+        buffer.writeByte((byte) 0x00);
+        buffer.writeByte(addressType.byteValue());
         switch (addressType) {
             case IPv4:
             case IPv6: {
-                byteBuf.writeBytes(NetUtil.createByteArrayFromIpAddressString(host));
-                byteBuf.writeShort((short) port);
+                buffer.writeBytes(NetUtil.createByteArrayFromIpAddressString(host));
+                buffer.writeShort((short) port);
                 break;
             }
 
             case DOMAIN: {
-                byteBuf.writeByte((byte) host.length());
-                byteBuf.writeCharSequence(host, CharsetUtil.US_ASCII);
-                byteBuf.writeShort((short) port);
+                buffer.writeByte((byte) host.length());
+                buffer.writeCharSequence(host, CharsetUtil.US_ASCII);
+                buffer.writeShort((short) port);
                 break;
             }
         }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdRequestDecoder.java
@@ -38,60 +38,60 @@ public class SocksCmdRequestDecoder extends ByteToMessageDecoderForBuffer {
     private SocksAddressType addressType;
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, Buffer byteBuf) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, Buffer buffer) throws Exception {
         switch (state) {
             case CHECK_PROTOCOL_VERSION: {
-                if (byteBuf.readableBytes() < 1) {
+                if (buffer.readableBytes() < 1) {
                     return;
                 }
-                if (byteBuf.readByte() != SocksProtocolVersion.SOCKS5.byteValue()) {
+                if (buffer.readByte() != SocksProtocolVersion.SOCKS5.byteValue()) {
                     ctx.fireChannelRead(SocksCommonUtils.UNKNOWN_SOCKS_REQUEST);
                     break;
                 }
                 state = State.READ_CMD_HEADER;
             }
             case READ_CMD_HEADER: {
-                if (byteBuf.readableBytes() < 3) {
+                if (buffer.readableBytes() < 3) {
                     return;
                 }
-                cmdType = SocksCmdType.valueOf(byteBuf.readByte());
-                byteBuf.skipReadable(1); // reserved
-                addressType = SocksAddressType.valueOf(byteBuf.readByte());
+                cmdType = SocksCmdType.valueOf(buffer.readByte());
+                buffer.skipReadable(1); // reserved
+                addressType = SocksAddressType.valueOf(buffer.readByte());
                 state = State.READ_CMD_ADDRESS;
             }
             case READ_CMD_ADDRESS: {
                 switch (addressType) {
                     case IPv4: {
-                        if (byteBuf.readableBytes() < 6) {
+                        if (buffer.readableBytes() < 6) {
                             return;
                         }
-                        String host = NetUtil.intToIpAddress(byteBuf.readInt());
-                        int port = byteBuf.readUnsignedShort();
+                        String host = NetUtil.intToIpAddress(buffer.readInt());
+                        int port = buffer.readUnsignedShort();
                         ctx.fireChannelRead(new SocksCmdRequest(cmdType, addressType, host, port));
                         break;
                     }
                     case DOMAIN: {
-                        if (byteBuf.readableBytes() < 1) {
+                        if (buffer.readableBytes() < 1) {
                             return;
                         }
-                        int fieldLength = byteBuf.getByte(byteBuf.readerOffset());
-                        if (byteBuf.readableBytes() < 3 + fieldLength) {
+                        int fieldLength = buffer.getByte(buffer.readerOffset());
+                        if (buffer.readableBytes() < 3 + fieldLength) {
                             return;
                         }
-                        byteBuf.skipReadable(1);
-                        String host = byteBuf.readCharSequence(fieldLength, CharsetUtil.US_ASCII).toString();
-                        int port = byteBuf.readUnsignedShort();
+                        buffer.skipReadable(1);
+                        String host = buffer.readCharSequence(fieldLength, CharsetUtil.US_ASCII).toString();
+                        int port = buffer.readUnsignedShort();
                         ctx.fireChannelRead(new SocksCmdRequest(cmdType, addressType, host, port));
                         break;
                     }
                     case IPv6: {
-                        if (byteBuf.readableBytes() < 18) {
+                        if (buffer.readableBytes() < 18) {
                             return;
                         }
                         byte[] bytes = new byte[16];
-                        byteBuf.readBytes(bytes, 0, bytes.length);
+                        buffer.readBytes(bytes, 0, bytes.length);
                         String host = SocksCommonUtils.ipv6toStr(bytes);
-                        int port = byteBuf.readUnsignedShort();
+                        int port = buffer.readUnsignedShort();
                         ctx.fireChannelRead(new SocksCmdRequest(cmdType, addressType, host, port));
                         break;
                     }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdResponse.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdResponse.java
@@ -138,35 +138,35 @@ public final class SocksCmdResponse extends SocksResponse {
     }
 
     @Override
-    public void encodeAsByteBuf(Buffer byteBuf) {
-        byteBuf.writeByte(protocolVersion().byteValue());
-        byteBuf.writeByte(cmdStatus.byteValue());
-        byteBuf.writeByte((byte) 0x00);
-        byteBuf.writeByte(addressType.byteValue());
+    public void encodeAsBuffer(Buffer buffer) {
+        buffer.writeByte(protocolVersion().byteValue());
+        buffer.writeByte(cmdStatus.byteValue());
+        buffer.writeByte((byte) 0x00);
+        buffer.writeByte(addressType.byteValue());
         switch (addressType) {
             case IPv4: {
                 byte[] hostContent = host == null ?
                         IPv4_HOSTNAME_ZEROED : NetUtil.createByteArrayFromIpAddressString(host);
-                byteBuf.writeBytes(hostContent);
-                byteBuf.writeShort((short) port);
+                buffer.writeBytes(hostContent);
+                buffer.writeShort((short) port);
                 break;
             }
             case DOMAIN: {
                 if (host != null) {
-                    byteBuf.writeByte((byte) host.length());
-                    byteBuf.writeCharSequence(host, CharsetUtil.US_ASCII);
+                    buffer.writeByte((byte) host.length());
+                    buffer.writeCharSequence(host, CharsetUtil.US_ASCII);
                 } else {
-                    byteBuf.writeByte((byte) DOMAIN_ZEROED.length);
-                    byteBuf.writeBytes(DOMAIN_ZEROED);
+                    buffer.writeByte((byte) DOMAIN_ZEROED.length);
+                    buffer.writeBytes(DOMAIN_ZEROED);
                 }
-                byteBuf.writeShort((short) port);
+                buffer.writeShort((short) port);
                 break;
             }
             case IPv6: {
                 byte[] hostContent = host == null
                         ? IPv6_HOSTNAME_ZEROED : NetUtil.createByteArrayFromIpAddressString(host);
-                byteBuf.writeBytes(hostContent);
-                byteBuf.writeShort((short) port);
+                buffer.writeBytes(hostContent);
+                buffer.writeShort((short) port);
                 break;
             }
         }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdResponse.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdResponse.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.NetUtil;
 
@@ -138,35 +138,35 @@ public final class SocksCmdResponse extends SocksResponse {
     }
 
     @Override
-    public void encodeAsByteBuf(ByteBuf byteBuf) {
+    public void encodeAsByteBuf(Buffer byteBuf) {
         byteBuf.writeByte(protocolVersion().byteValue());
         byteBuf.writeByte(cmdStatus.byteValue());
-        byteBuf.writeByte(0x00);
+        byteBuf.writeByte((byte) 0x00);
         byteBuf.writeByte(addressType.byteValue());
         switch (addressType) {
             case IPv4: {
                 byte[] hostContent = host == null ?
                         IPv4_HOSTNAME_ZEROED : NetUtil.createByteArrayFromIpAddressString(host);
                 byteBuf.writeBytes(hostContent);
-                byteBuf.writeShort(port);
+                byteBuf.writeShort((short) port);
                 break;
             }
             case DOMAIN: {
                 if (host != null) {
-                    byteBuf.writeByte(host.length());
+                    byteBuf.writeByte((byte) host.length());
                     byteBuf.writeCharSequence(host, CharsetUtil.US_ASCII);
                 } else {
-                    byteBuf.writeByte(DOMAIN_ZEROED.length);
+                    byteBuf.writeByte((byte) DOMAIN_ZEROED.length);
                     byteBuf.writeBytes(DOMAIN_ZEROED);
                 }
-                byteBuf.writeShort(port);
+                byteBuf.writeShort((short) port);
                 break;
             }
             case IPv6: {
                 byte[] hostContent = host == null
                         ? IPv6_HOSTNAME_ZEROED : NetUtil.createByteArrayFromIpAddressString(host);
                 byteBuf.writeBytes(hostContent);
-                byteBuf.writeShort(port);
+                byteBuf.writeShort((short) port);
                 break;
             }
         }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCommonUtils.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCommonUtils.java
@@ -15,8 +15,6 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty.buffer.ByteBuf;
-import io.netty5.util.CharsetUtil;
 import io.netty5.util.internal.StringUtil;
 
 final class SocksCommonUtils {
@@ -55,11 +53,5 @@ final class SocksCommonUtils {
 
     private static void appendHextet(StringBuilder sb, byte[] src, int i) {
         StringUtil.toHexString(sb, src, i << 1, 2);
-    }
-
-    static String readUsAscii(ByteBuf buffer, int length) {
-        String s = buffer.toString(buffer.readerIndex(), length, CharsetUtil.US_ASCII);
-        buffer.skipBytes(length);
-        return s;
     }
 }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitRequest.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitRequest.java
@@ -47,11 +47,11 @@ public final class SocksInitRequest extends SocksRequest {
     }
 
     @Override
-    public void encodeAsByteBuf(Buffer byteBuf) {
-        byteBuf.writeByte(protocolVersion().byteValue());
-        byteBuf.writeByte((byte) authSchemes.size());
+    public void encodeAsBuffer(Buffer buffer) {
+        buffer.writeByte(protocolVersion().byteValue());
+        buffer.writeByte((byte) authSchemes.size());
         for (SocksAuthScheme authScheme : authSchemes) {
-            byteBuf.writeByte(authScheme.byteValue());
+            buffer.writeByte(authScheme.byteValue());
         }
     }
 }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitRequest.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitRequest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 
 import java.util.Collections;
 import java.util.List;
@@ -47,9 +47,9 @@ public final class SocksInitRequest extends SocksRequest {
     }
 
     @Override
-    public void encodeAsByteBuf(ByteBuf byteBuf) {
+    public void encodeAsByteBuf(Buffer byteBuf) {
         byteBuf.writeByte(protocolVersion().byteValue());
-        byteBuf.writeByte(authSchemes.size());
+        byteBuf.writeByte((byte) authSchemes.size());
         for (SocksAuthScheme authScheme : authSchemes) {
             byteBuf.writeByte(authScheme.byteValue());
         }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitRequestDecoder.java
@@ -36,32 +36,32 @@ public class SocksInitRequestDecoder extends ByteToMessageDecoderForBuffer {
     private State state = State.CHECK_PROTOCOL_VERSION;
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, Buffer byteBuf) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, Buffer buffer) throws Exception {
         switch (state) {
             case CHECK_PROTOCOL_VERSION: {
-                if (byteBuf.readableBytes() < 1) {
+                if (buffer.readableBytes() < 1) {
                     return;
                 }
-                if (byteBuf.readByte() != SocksProtocolVersion.SOCKS5.byteValue()) {
+                if (buffer.readByte() != SocksProtocolVersion.SOCKS5.byteValue()) {
                     ctx.fireChannelRead(SocksCommonUtils.UNKNOWN_SOCKS_REQUEST);
                     break;
                 }
                 state = State.READ_AUTH_SCHEMES;
             }
             case READ_AUTH_SCHEMES: {
-                if (byteBuf.readableBytes() < 1) {
+                if (buffer.readableBytes() < 1) {
                     return;
                 }
-                final byte authSchemeNum = byteBuf.getByte(byteBuf.readerOffset());
-                if (byteBuf.readableBytes() < 1 + authSchemeNum) {
+                final byte authSchemeNum = buffer.getByte(buffer.readerOffset());
+                if (buffer.readableBytes() < 1 + authSchemeNum) {
                     return;
                 }
-                byteBuf.skipReadable(1);
+                buffer.skipReadable(1);
                 final List<SocksAuthScheme> authSchemes;
                 if (authSchemeNum > 0) {
                     authSchemes = new ArrayList<>(authSchemeNum);
                     for (int i = 0; i < authSchemeNum; i++) {
-                        authSchemes.add(SocksAuthScheme.valueOf(byteBuf.readByte()));
+                        authSchemes.add(SocksAuthScheme.valueOf(buffer.readByte()));
                     }
                 } else {
                     authSchemes = Collections.emptyList();

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitRequestDecoder.java
@@ -15,19 +15,19 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoder;
+import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 /**
- * Decodes {@link ByteBuf}s into {@link SocksInitRequest}.
+ * Decodes {@link Buffer}s into {@link SocksInitRequest}.
  * Before returning SocksRequest decoder removes itself from pipeline.
  */
-public class SocksInitRequestDecoder extends ByteToMessageDecoder {
+public class SocksInitRequestDecoder extends ByteToMessageDecoderForBuffer {
 
     private enum State {
         CHECK_PROTOCOL_VERSION,
@@ -36,7 +36,7 @@ public class SocksInitRequestDecoder extends ByteToMessageDecoder {
     private State state = State.CHECK_PROTOCOL_VERSION;
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, ByteBuf byteBuf) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, Buffer byteBuf) throws Exception {
         switch (state) {
             case CHECK_PROTOCOL_VERSION: {
                 if (byteBuf.readableBytes() < 1) {
@@ -52,11 +52,11 @@ public class SocksInitRequestDecoder extends ByteToMessageDecoder {
                 if (byteBuf.readableBytes() < 1) {
                     return;
                 }
-                final byte authSchemeNum = byteBuf.getByte(byteBuf.readerIndex());
+                final byte authSchemeNum = byteBuf.getByte(byteBuf.readerOffset());
                 if (byteBuf.readableBytes() < 1 + authSchemeNum) {
                     return;
                 }
-                byteBuf.skipBytes(1);
+                byteBuf.skipReadable(1);
                 final List<SocksAuthScheme> authSchemes;
                 if (authSchemeNum > 0) {
                     authSchemes = new ArrayList<>(authSchemeNum);

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitResponse.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitResponse.java
@@ -44,8 +44,8 @@ public final class SocksInitResponse extends SocksResponse {
     }
 
     @Override
-    public void encodeAsByteBuf(Buffer byteBuf) {
-        byteBuf.writeByte(protocolVersion().byteValue());
-        byteBuf.writeByte(authScheme.byteValue());
+    public void encodeAsBuffer(Buffer buffer) {
+        buffer.writeByte(protocolVersion().byteValue());
+        buffer.writeByte(authScheme.byteValue());
     }
 }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitResponse.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitResponse.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 
 import static java.util.Objects.requireNonNull;
 
@@ -44,7 +44,7 @@ public final class SocksInitResponse extends SocksResponse {
     }
 
     @Override
-    public void encodeAsByteBuf(ByteBuf byteBuf) {
+    public void encodeAsByteBuf(Buffer byteBuf) {
         byteBuf.writeByte(protocolVersion().byteValue());
         byteBuf.writeByte(authScheme.byteValue());
     }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitResponseDecoder.java
@@ -32,23 +32,23 @@ public class SocksInitResponseDecoder extends ByteToMessageDecoderForBuffer {
     private State state = State.CHECK_PROTOCOL_VERSION;
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, Buffer byteBuf) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, Buffer buffer) throws Exception {
         switch (state) {
             case CHECK_PROTOCOL_VERSION: {
-                if (byteBuf.readableBytes() < 1) {
+                if (buffer.readableBytes() < 1) {
                     return;
                 }
-                if (byteBuf.readByte() != SocksProtocolVersion.SOCKS5.byteValue()) {
+                if (buffer.readByte() != SocksProtocolVersion.SOCKS5.byteValue()) {
                     ctx.fireChannelRead(SocksCommonUtils.UNKNOWN_SOCKS_RESPONSE);
                     break;
                 }
                 state = State.READ_PREFERRED_AUTH_TYPE;
             }
             case READ_PREFERRED_AUTH_TYPE: {
-                if (byteBuf.readableBytes() < 1) {
+                if (buffer.readableBytes() < 1) {
                     return;
                 }
-                SocksAuthScheme authScheme = SocksAuthScheme.valueOf(byteBuf.readByte());
+                SocksAuthScheme authScheme = SocksAuthScheme.valueOf(buffer.readByte());
                 ctx.fireChannelRead(new SocksInitResponse(authScheme));
                 break;
             }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitResponseDecoder.java
@@ -15,15 +15,15 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoder;
+import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
 
 /**
- * Decodes {@link ByteBuf}s into {@link SocksInitResponse}.
+ * Decodes {@link Buffer}s into {@link SocksInitResponse}.
  * Before returning SocksResponse decoder removes itself from pipeline.
  */
-public class SocksInitResponseDecoder extends ByteToMessageDecoder {
+public class SocksInitResponseDecoder extends ByteToMessageDecoderForBuffer {
 
     private enum State {
         CHECK_PROTOCOL_VERSION,
@@ -32,7 +32,7 @@ public class SocksInitResponseDecoder extends ByteToMessageDecoder {
     private State state = State.CHECK_PROTOCOL_VERSION;
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, ByteBuf byteBuf) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, Buffer byteBuf) throws Exception {
         switch (state) {
             case CHECK_PROTOCOL_VERSION: {
                 if (byteBuf.readableBytes() < 1) {

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksMessage.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksMessage.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 
 import static java.util.Objects.requireNonNull;
 
@@ -57,5 +57,5 @@ public abstract class SocksMessage {
      * @deprecated Do not use; this method was intended for an internal use only.
      */
     @Deprecated
-    public abstract void encodeAsByteBuf(ByteBuf byteBuf);
+    public abstract void encodeAsByteBuf(Buffer byteBuf);
 }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksMessage.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksMessage.java
@@ -57,5 +57,5 @@ public abstract class SocksMessage {
      * @deprecated Do not use; this method was intended for an internal use only.
      */
     @Deprecated
-    public abstract void encodeAsByteBuf(Buffer byteBuf);
+    public abstract void encodeAsBuffer(Buffer buffer);
 }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksMessageEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksMessageEncoder.java
@@ -15,22 +15,28 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.MessageToByteEncoder;
+import io.netty5.handler.codec.MessageToByteEncoderForBuffer;
 
 /**
- * Encodes an {@link SocksMessage} into a {@link ByteBuf}.
- * {@link MessageToByteEncoder} implementation.
+ * Encodes an {@link SocksMessage} into a {@link Buffer}.
+ * {@link MessageToByteEncoderForBuffer} implementation.
  * Use this with {@link SocksInitRequest}, {@link SocksInitResponse}, {@link SocksAuthRequest},
  * {@link SocksAuthResponse}, {@link SocksCmdRequest} and {@link SocksCmdResponse}
  */
 @ChannelHandler.Sharable
-public class SocksMessageEncoder extends MessageToByteEncoder<SocksMessage> {
+public class SocksMessageEncoder extends MessageToByteEncoderForBuffer<SocksMessage> {
+
+    @Override
+    protected Buffer allocateBuffer(ChannelHandlerContext ctx, SocksMessage msg) {
+        return ctx.bufferAllocator().allocate(256);
+    }
+
     @Override
     @SuppressWarnings("deprecation")
-    protected void encode(ChannelHandlerContext ctx, SocksMessage msg, ByteBuf out) throws Exception {
+    protected void encode(ChannelHandlerContext ctx, SocksMessage msg, Buffer out) {
         msg.encodeAsByteBuf(out);
     }
 }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksMessageEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksMessageEncoder.java
@@ -37,6 +37,6 @@ public class SocksMessageEncoder extends MessageToByteEncoderForBuffer<SocksMess
     @Override
     @SuppressWarnings("deprecation")
     protected void encode(ChannelHandlerContext ctx, SocksMessage msg, Buffer out) {
-        msg.encodeAsByteBuf(out);
+        msg.encodeAsBuffer(out);
     }
 }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/UnknownSocksRequest.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/UnknownSocksRequest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 
 /**
  * An unknown socks request.
@@ -31,7 +31,7 @@ public final class UnknownSocksRequest extends SocksRequest {
     }
 
     @Override
-    public void encodeAsByteBuf(ByteBuf byteBuf) {
+    public void encodeAsByteBuf(Buffer byteBuf) {
         // NOOP
     }
 }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/UnknownSocksRequest.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/UnknownSocksRequest.java
@@ -31,7 +31,7 @@ public final class UnknownSocksRequest extends SocksRequest {
     }
 
     @Override
-    public void encodeAsByteBuf(Buffer byteBuf) {
+    public void encodeAsBuffer(Buffer buffer) {
         // NOOP
     }
 }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/UnknownSocksResponse.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/UnknownSocksResponse.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 
 /**
  * An unknown socks response.
@@ -31,7 +31,7 @@ public final class UnknownSocksResponse extends SocksResponse {
     }
 
     @Override
-    public void encodeAsByteBuf(ByteBuf byteBuf) {
+    public void encodeAsByteBuf(Buffer byteBuf) {
         // NOOP
     }
 }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/UnknownSocksResponse.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/UnknownSocksResponse.java
@@ -31,7 +31,7 @@ public final class UnknownSocksResponse extends SocksResponse {
     }
 
     @Override
-    public void encodeAsByteBuf(Buffer byteBuf) {
+    public void encodeAsBuffer(Buffer buffer) {
         // NOOP
     }
 }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/SocksPortUnificationServerHandler.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/SocksPortUnificationServerHandler.java
@@ -15,15 +15,15 @@
  */
 package io.netty.contrib.handler.codec.socksx;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
-import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty.contrib.handler.codec.socksx.v4.Socks4ServerDecoder;
 import io.netty.contrib.handler.codec.socksx.v4.Socks4ServerEncoder;
 import io.netty.contrib.handler.codec.socksx.v5.Socks5AddressEncoder;
 import io.netty.contrib.handler.codec.socksx.v5.Socks5InitialRequestDecoder;
 import io.netty.contrib.handler.codec.socksx.v5.Socks5ServerEncoder;
+import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
 
@@ -33,7 +33,7 @@ import static java.util.Objects.requireNonNull;
  * Detects the version of the current SOCKS connection and initializes the pipeline with
  * {@link Socks4ServerDecoder} or {@link Socks5InitialRequestDecoder}.
  */
-public class SocksPortUnificationServerHandler extends ByteToMessageDecoder {
+public class SocksPortUnificationServerHandler extends ByteToMessageDecoderForBuffer {
 
     private static final InternalLogger logger =
             InternalLoggerFactory.getInstance(SocksPortUnificationServerHandler.class);
@@ -58,9 +58,9 @@ public class SocksPortUnificationServerHandler extends ByteToMessageDecoder {
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, ByteBuf in) throws Exception {
-        final int readerIndex = in.readerIndex();
-        if (in.writerIndex() == readerIndex) {
+    protected void decode(ChannelHandlerContext ctx, Buffer in) throws Exception {
+        final int readerIndex = in.readerOffset();
+        if (in.writerOffset() == readerIndex) {
             return;
         }
 
@@ -81,7 +81,7 @@ public class SocksPortUnificationServerHandler extends ByteToMessageDecoder {
             break;
         default:
             logUnknownVersion(ctx, versionVal);
-            in.skipBytes(in.readableBytes());
+            in.skipReadable(in.readableBytes());
             ctx.close();
             return;
         }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ClientDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ClientDecoder.java
@@ -15,20 +15,20 @@
  */
 package io.netty.contrib.handler.codec.socksx.v4;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoder;
+import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
 import io.netty5.handler.codec.DecoderException;
 import io.netty5.handler.codec.DecoderResult;
 import io.netty5.util.NetUtil;
 
 /**
- * Decodes a single {@link Socks4CommandResponse} from the inbound {@link ByteBuf}s.
+ * Decodes a single {@link Socks4CommandResponse} from the inbound {@link Buffer}s.
  * On successful decode, this decoder will forward the received data to the next handler, so that
  * other handler can remove this decoder later.  On failed decode, this decoder will discard the
  * received data, so that other handler closes the connection later.
  */
-public class Socks4ClientDecoder extends ByteToMessageDecoder {
+public class Socks4ClientDecoder extends ByteToMessageDecoderForBuffer {
 
     private enum State {
         START,
@@ -43,7 +43,7 @@ public class Socks4ClientDecoder extends ByteToMessageDecoder {
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, ByteBuf in) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, Buffer in) throws Exception {
         try {
             switch (state) {
             case START: {
@@ -67,12 +67,12 @@ public class Socks4ClientDecoder extends ByteToMessageDecoder {
             case SUCCESS: {
                 int readableBytes = actualReadableBytes();
                 if (readableBytes > 0) {
-                    ctx.fireChannelRead(in.readRetainedSlice(readableBytes));
+                    ctx.fireChannelRead(in.readSplit(readableBytes));
                 }
                 break;
             }
             case FAILURE: {
-                in.skipBytes(actualReadableBytes());
+                in.skipReadable(actualReadableBytes());
                 break;
             }
             }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ServerDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ServerDecoder.java
@@ -129,9 +129,8 @@ public class Socks4ServerDecoder extends ByteToMessageDecoderForBuffer {
      * Reads a variable-length NUL-terminated string as defined in SOCKS4.
      */
     private static String readString(String fieldName, Buffer in) {
-        int length = in.openCursor(in.readerOffset(), Math.min(in.readableBytes(), MAX_FIELD_LENGTH + 1))
-                .process(ByteProcessor.FIND_NUL);
-        if (length >= 0) {
+        int length = in.bytesBefore((byte) 0);
+        if (length >= 0 && length < MAX_FIELD_LENGTH) {
             if (in.readableBytes() < length + 1) {
                 return null;
             }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ServerDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ServerDecoder.java
@@ -15,22 +15,23 @@
  */
 package io.netty.contrib.handler.codec.socksx.v4;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoder;
+import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
 import io.netty5.handler.codec.DecoderException;
 import io.netty5.handler.codec.DecoderResult;
 import io.netty.contrib.handler.codec.socksx.SocksVersion;
+import io.netty5.util.ByteProcessor;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.NetUtil;
 
 /**
- * Decodes a single {@link Socks4CommandRequest} from the inbound {@link ByteBuf}s.
+ * Decodes a single {@link Socks4CommandRequest} from the inbound {@link Buffer}s.
  * On successful decode, this decoder will forward the received data to the next handler, so that
  * other handler can remove this decoder later.  On failed decode, this decoder will discard the
  * received data, so that other handler closes the connection later.
  */
-public class Socks4ServerDecoder extends ByteToMessageDecoder {
+public class Socks4ServerDecoder extends ByteToMessageDecoderForBuffer {
 
     private static final int MAX_FIELD_LENGTH = 255;
 
@@ -53,7 +54,7 @@ public class Socks4ServerDecoder extends ByteToMessageDecoder {
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, ByteBuf in) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, Buffer in) throws Exception {
         try {
             switch (state) {
             case START: {
@@ -93,12 +94,12 @@ public class Socks4ServerDecoder extends ByteToMessageDecoder {
             case SUCCESS: {
                 int readableBytes = actualReadableBytes();
                 if (readableBytes > 0) {
-                    ctx.fireChannelRead(in.readRetainedSlice(readableBytes));
+                    ctx.fireChannelRead(in.readSplit(readableBytes));
                 }
                 break;
             }
             case FAILURE: {
-                in.skipBytes(actualReadableBytes());
+                in.skipReadable(actualReadableBytes());
                 break;
             }
             }
@@ -127,14 +128,15 @@ public class Socks4ServerDecoder extends ByteToMessageDecoder {
     /**
      * Reads a variable-length NUL-terminated string as defined in SOCKS4.
      */
-    private static String readString(String fieldName, ByteBuf in) {
-        int length = in.bytesBefore(Math.min(in.readableBytes(), MAX_FIELD_LENGTH + 1), (byte) 0);
+    private static String readString(String fieldName, Buffer in) {
+        int length = in.openCursor(in.readerOffset(), Math.min(in.readableBytes(), MAX_FIELD_LENGTH + 1))
+                .process(ByteProcessor.FIND_NUL);
         if (length >= 0) {
             if (in.readableBytes() < length + 1) {
                 return null;
             }
-            String value = in.readSlice(length).toString(CharsetUtil.US_ASCII);
-            in.skipBytes(1); // Skip the NUL.
+            String value = in.readCharSequence(length, CharsetUtil.US_ASCII).toString();
+            in.skipReadable(1); // Skip the NUL.
 
             return value;
         }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ServerEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ServerEncoder.java
@@ -15,17 +15,17 @@
  */
 package io.netty.contrib.handler.codec.socksx.v4;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.MessageToByteEncoder;
+import io.netty5.handler.codec.MessageToByteEncoderForBuffer;
 import io.netty5.util.NetUtil;
 
 /**
- * Encodes a {@link Socks4CommandResponse} into a {@link ByteBuf}.
+ * Encodes a {@link Socks4CommandResponse} into a {@link Buffer}.
  */
 @Sharable
-public final class Socks4ServerEncoder extends MessageToByteEncoder<Socks4CommandResponse> {
+public final class Socks4ServerEncoder extends MessageToByteEncoderForBuffer<Socks4CommandResponse> {
 
     public static final Socks4ServerEncoder INSTANCE = new Socks4ServerEncoder();
 
@@ -34,10 +34,15 @@ public final class Socks4ServerEncoder extends MessageToByteEncoder<Socks4Comman
     private Socks4ServerEncoder() { }
 
     @Override
-    protected void encode(ChannelHandlerContext ctx, Socks4CommandResponse msg, ByteBuf out) throws Exception {
-        out.writeByte(0);
+    protected Buffer allocateBuffer(ChannelHandlerContext ctx, Socks4CommandResponse msg) {
+        return ctx.bufferAllocator().allocate(256);
+    }
+
+    @Override
+    protected void encode(ChannelHandlerContext ctx, Socks4CommandResponse msg, Buffer out) {
+        out.writeByte((byte) 0);
         out.writeByte(msg.status().byteValue());
-        out.writeShort(msg.dstPort());
+        out.writeShort((short) msg.dstPort());
         out.writeBytes(msg.dstAddr() == null? IPv4_HOSTNAME_ZEROED
                                             : NetUtil.createByteArrayFromIpAddressString(msg.dstAddr()));
     }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5AddressEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5AddressEncoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.handler.codec.EncoderException;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.NetUtil;
@@ -38,10 +38,10 @@ public interface Socks5AddressEncoder {
             }
         } else if (typeVal == Socks5AddressType.DOMAIN.byteValue()) {
             if (addrValue != null) {
-                out.writeByte(addrValue.length());
+                out.writeByte((byte) addrValue.length());
                 out.writeCharSequence(addrValue, CharsetUtil.US_ASCII);
             } else {
-                out.writeByte(0);
+                out.writeByte((byte) 0);
             }
         } else if (typeVal == Socks5AddressType.IPv6.byteValue()) {
             if (addrValue != null) {
@@ -62,5 +62,5 @@ public interface Socks5AddressEncoder {
      * @param addrValue the string representation of the address
      * @param out the output buffer where the encoded SOCKS5 address field will be written to
      */
-    void encodeAddress(Socks5AddressType addrType, String addrValue, ByteBuf out) throws Exception;
+    void encodeAddress(Socks5AddressType addrType, String addrValue, Buffer out) throws Exception;
 }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5CommandResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5CommandResponseDecoder.java
@@ -15,9 +15,9 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoder;
+import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
 import io.netty5.handler.codec.DecoderException;
 import io.netty5.handler.codec.DecoderResult;
 import io.netty.contrib.handler.codec.socksx.SocksVersion;
@@ -25,12 +25,12 @@ import io.netty.contrib.handler.codec.socksx.SocksVersion;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Decodes a single {@link Socks5CommandResponse} from the inbound {@link ByteBuf}s.
+ * Decodes a single {@link Socks5CommandResponse} from the inbound {@link Buffer}s.
  * On successful decode, this decoder will forward the received data to the next handler, so that
  * other handler can remove or replace this decoder later.  On failed decode, this decoder will
  * discard the received data, so that other handler closes the connection later.
  */
-public class Socks5CommandResponseDecoder extends ByteToMessageDecoder {
+public class Socks5CommandResponseDecoder extends ByteToMessageDecoderForBuffer {
 
     private enum State {
         INIT,
@@ -49,25 +49,25 @@ public class Socks5CommandResponseDecoder extends ByteToMessageDecoder {
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, ByteBuf in) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, Buffer in) throws Exception {
         try {
             switch (state) {
             case INIT: {
                 if (in.readableBytes() < 6) {
                     return;
                 }
-                int readerIndex = in.readerIndex();
+                int readerIndex = in.readerOffset();
                 final byte version = in.readByte();
                 if (version != SocksVersion.SOCKS5.byteValue()) {
                     throw new DecoderException(
                             "unsupported version: " + version + " (expected: " + SocksVersion.SOCKS5.byteValue() + ')');
                 }
                 final Socks5CommandStatus status = Socks5CommandStatus.valueOf(in.readByte());
-                in.skipBytes(1); // Reserved
+                in.skipReadable(1); // Reserved
                 final Socks5AddressType addrType = Socks5AddressType.valueOf(in.readByte());
                 final String addr = addressDecoder.decodeAddress(addrType, in);
                 if (addr == null || in.readableBytes() < 2) {
-                    in.readerIndex(readerIndex);
+                    in.readerOffset(readerIndex);
                     return;
                 }
                 final int port = in.readUnsignedShort();
@@ -78,12 +78,12 @@ public class Socks5CommandResponseDecoder extends ByteToMessageDecoder {
             case SUCCESS: {
                 int readableBytes = actualReadableBytes();
                 if (readableBytes > 0) {
-                    ctx.fireChannelRead(in.readRetainedSlice(readableBytes));
+                    ctx.fireChannelRead(in.readSplit(readableBytes));
                 }
                 break;
             }
             case FAILURE: {
-                in.skipBytes(actualReadableBytes());
+                in.skipReadable(actualReadableBytes());
                 break;
             }
             }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5InitialRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5InitialRequestDecoder.java
@@ -15,20 +15,20 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoder;
+import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
 import io.netty5.handler.codec.DecoderException;
 import io.netty5.handler.codec.DecoderResult;
 import io.netty.contrib.handler.codec.socksx.SocksVersion;
 
 /**
- * Decodes a single {@link Socks5InitialRequest} from the inbound {@link ByteBuf}s.
+ * Decodes a single {@link Socks5InitialRequest} from the inbound {@link Buffer}s.
  * On successful decode, this decoder will forward the received data to the next handler, so that
  * other handler can remove or replace this decoder later.  On failed decode, this decoder will
  * discard the received data, so that other handler closes the connection later.
  */
-public class Socks5InitialRequestDecoder extends ByteToMessageDecoder {
+public class Socks5InitialRequestDecoder extends ByteToMessageDecoderForBuffer {
 
     private enum State {
         INIT,
@@ -39,14 +39,14 @@ public class Socks5InitialRequestDecoder extends ByteToMessageDecoder {
     private State state = State.INIT;
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, ByteBuf in) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, Buffer in) throws Exception {
         try {
             switch (state) {
             case INIT: {
                 if (in.readableBytes() < 2) {
                     return;
                 }
-                int readerIndex = in.readerIndex();
+                int readerIndex = in.readerOffset();
                 final byte version = in.readByte();
                 if (version != SocksVersion.SOCKS5.byteValue()) {
                     throw new DecoderException(
@@ -56,7 +56,7 @@ public class Socks5InitialRequestDecoder extends ByteToMessageDecoder {
                 final int authMethodCnt = in.readUnsignedByte();
 
                 if (in.readableBytes() < authMethodCnt) {
-                    in.readerIndex(readerIndex);
+                    in.readerOffset(readerIndex);
                     return;
                 }
                 final Socks5AuthMethod[] authMethods = new Socks5AuthMethod[authMethodCnt];
@@ -70,12 +70,12 @@ public class Socks5InitialRequestDecoder extends ByteToMessageDecoder {
             case SUCCESS: {
                 int readableBytes = actualReadableBytes();
                 if (readableBytes > 0) {
-                    ctx.fireChannelRead(in.readRetainedSlice(readableBytes));
+                    ctx.fireChannelRead(in.readSplit(readableBytes));
                 }
                 break;
             }
             case FAILURE: {
-                in.skipBytes(actualReadableBytes());
+                in.skipReadable(actualReadableBytes());
                 break;
             }
             }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5InitialResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5InitialResponseDecoder.java
@@ -15,20 +15,20 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoder;
+import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
 import io.netty5.handler.codec.DecoderException;
 import io.netty5.handler.codec.DecoderResult;
 import io.netty.contrib.handler.codec.socksx.SocksVersion;
 
 /**
- * Decodes a single {@link Socks5InitialResponse} from the inbound {@link ByteBuf}s.
+ * Decodes a single {@link Socks5InitialResponse} from the inbound {@link Buffer}s.
  * On successful decode, this decoder will forward the received data to the next handler, so that
  * other handler can remove or replace this decoder later.  On failed decode, this decoder will
  * discard the received data, so that other handler closes the connection later.
  */
-public class Socks5InitialResponseDecoder extends ByteToMessageDecoder {
+public class Socks5InitialResponseDecoder extends ByteToMessageDecoderForBuffer {
 
     private enum State {
         INIT,
@@ -39,7 +39,7 @@ public class Socks5InitialResponseDecoder extends ByteToMessageDecoder {
     private State state = State.INIT;
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, ByteBuf in) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, Buffer in) throws Exception {
         try {
             switch (state) {
             case INIT: {
@@ -59,12 +59,12 @@ public class Socks5InitialResponseDecoder extends ByteToMessageDecoder {
             case SUCCESS: {
                 int readableBytes = actualReadableBytes();
                 if (readableBytes > 0) {
-                    ctx.fireChannelRead(in.readRetainedSlice(readableBytes));
+                    ctx.fireChannelRead(in.readSplit(readableBytes));
                 }
                 break;
             }
             case FAILURE: {
-                in.skipBytes(actualReadableBytes());
+                in.skipReadable(actualReadableBytes());
                 break;
             }
             }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5PasswordAuthResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5PasswordAuthResponseDecoder.java
@@ -15,19 +15,19 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoder;
+import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
 import io.netty5.handler.codec.DecoderException;
 import io.netty5.handler.codec.DecoderResult;
 
 /**
- * Decodes a single {@link Socks5PasswordAuthResponse} from the inbound {@link ByteBuf}s.
+ * Decodes a single {@link Socks5PasswordAuthResponse} from the inbound {@link Buffer}s.
  * On successful decode, this decoder will forward the received data to the next handler, so that
  * other handler can remove or replace this decoder later.  On failed decode, this decoder will
  * discard the received data, so that other handler closes the connection later.
  */
-public class Socks5PasswordAuthResponseDecoder extends ByteToMessageDecoder {
+public class Socks5PasswordAuthResponseDecoder extends ByteToMessageDecoderForBuffer {
 
     private enum State {
         INIT,
@@ -38,7 +38,7 @@ public class Socks5PasswordAuthResponseDecoder extends ByteToMessageDecoder {
     private State state = State.INIT;
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, ByteBuf in) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, Buffer in) throws Exception {
         try {
             switch (state) {
             case INIT: {
@@ -57,12 +57,12 @@ public class Socks5PasswordAuthResponseDecoder extends ByteToMessageDecoder {
             case SUCCESS: {
                 int readableBytes = actualReadableBytes();
                 if (readableBytes > 0) {
-                    ctx.fireChannelRead(in.readRetainedSlice(readableBytes));
+                    ctx.fireChannelRead(in.readSplit(readableBytes));
                 }
                 break;
             }
             case FAILURE: {
-                in.skipBytes(actualReadableBytes());
+                in.skipReadable(actualReadableBytes());
                 break;
             }
             }

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksAuthRequestDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksAuthRequestDecoderTest.java
@@ -15,8 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
 
@@ -44,20 +43,20 @@ public class SocksAuthRequestDecoderTest {
     @Test
     public void testAuthRequestDecoderPartialSend() {
         EmbeddedChannel ch = new EmbeddedChannel(new SocksAuthRequestDecoder());
-        ByteBuf byteBuf = Unpooled.buffer(16);
+        Buffer byteBuf = ch.bufferAllocator().allocate(16);
 
         // Send username and password size
         byteBuf.writeByte(SocksSubnegotiationVersion.AUTH_PASSWORD.byteValue());
-        byteBuf.writeByte(username.length());
+        byteBuf.writeByte((byte) username.length());
         byteBuf.writeBytes(username.getBytes());
-        byteBuf.writeByte(password.length());
+        byteBuf.writeByte((byte) password.length());
         ch.writeInbound(byteBuf);
 
         // Check that channel is empty
         assertNull(ch.readInbound());
 
         // Send password
-        ByteBuf byteBuf2 = Unpooled.buffer();
+        Buffer byteBuf2 = ch.bufferAllocator().allocate(16);
         byteBuf2.writeBytes(password.getBytes());
         ch.writeInbound(byteBuf2);
 

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksAuthRequestDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksAuthRequestDecoderTest.java
@@ -43,22 +43,22 @@ public class SocksAuthRequestDecoderTest {
     @Test
     public void testAuthRequestDecoderPartialSend() {
         EmbeddedChannel ch = new EmbeddedChannel(new SocksAuthRequestDecoder());
-        Buffer byteBuf = ch.bufferAllocator().allocate(16);
+        Buffer buffer = ch.bufferAllocator().allocate(16);
 
         // Send username and password size
-        byteBuf.writeByte(SocksSubnegotiationVersion.AUTH_PASSWORD.byteValue());
-        byteBuf.writeByte((byte) username.length());
-        byteBuf.writeBytes(username.getBytes());
-        byteBuf.writeByte((byte) password.length());
-        ch.writeInbound(byteBuf);
+        buffer.writeByte(SocksSubnegotiationVersion.AUTH_PASSWORD.byteValue());
+        buffer.writeByte((byte) username.length());
+        buffer.writeBytes(username.getBytes());
+        buffer.writeByte((byte) password.length());
+        ch.writeInbound(buffer);
 
         // Check that channel is empty
         assertNull(ch.readInbound());
 
         // Send password
-        Buffer byteBuf2 = ch.bufferAllocator().allocate(16);
-        byteBuf2.writeBytes(password.getBytes());
-        ch.writeInbound(byteBuf2);
+        Buffer buffer2 = ch.bufferAllocator().allocate(16);
+        buffer2.writeBytes(password.getBytes());
+        ch.writeInbound(buffer2);
 
         // Read message from channel
         SocksAuthRequest msg = ch.readInbound();

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCmdRequestTest.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCmdRequestTest.java
@@ -77,7 +77,7 @@ public class SocksCmdRequestTest {
         assertEquals(asciiHost, rq.host());
 
         try (Buffer buffer = preferredAllocator().allocate(16)) {
-            rq.encodeAsByteBuf(buffer);
+            rq.encodeAsBuffer(buffer);
 
             buffer.readerOffset(0);
             assertEquals(SocksProtocolVersion.SOCKS5.byteValue(), buffer.readByte());
@@ -98,7 +98,7 @@ public class SocksCmdRequestTest {
         assertEquals(host, rq.host());
 
         try (Buffer buffer = preferredAllocator().allocate(32)) {
-            rq.encodeAsByteBuf(buffer);
+            rq.encodeAsBuffer(buffer);
 
             buffer.readerOffset(0);
             assertEquals(SocksProtocolVersion.SOCKS5.byteValue(), buffer.readByte());

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCmdResponseTest.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCmdResponseTest.java
@@ -46,7 +46,7 @@ public class SocksCmdResponseTest {
         assertNull(socksCmdResponse.host());
         assertEquals(0, socksCmdResponse.port());
         try (Buffer buffer = preferredAllocator().allocate(20)) {
-            socksCmdResponse.encodeAsByteBuf(buffer);
+            socksCmdResponse.encodeAsBuffer(buffer);
             byte[] expected = {
                     0x05, // version
                     0x00, // success reply
@@ -71,7 +71,7 @@ public class SocksCmdResponseTest {
         assertEquals("127.0.0.1", socksCmdResponse.host());
         assertEquals(80, socksCmdResponse.port());
         try (Buffer buffer = preferredAllocator().allocate(20)) {
-            socksCmdResponse.encodeAsByteBuf(buffer);
+            socksCmdResponse.encodeAsBuffer(buffer);
             byte[] expected = {
                     0x05, // version
                     0x00, // success reply
@@ -98,7 +98,7 @@ public class SocksCmdResponseTest {
         assertEquals("", socksCmdResponse.host());
         assertEquals(80, socksCmdResponse.port());
         try (Buffer buffer = preferredAllocator().allocate(20)) {
-            socksCmdResponse.encodeAsByteBuf(buffer);
+            socksCmdResponse.encodeAsBuffer(buffer);
             byte[] expected = {
                     0x05, // version
                     0x00, // success reply
@@ -121,7 +121,7 @@ public class SocksCmdResponseTest {
         assertEquals(asciiHost, rs.host());
 
         try (Buffer buffer = preferredAllocator().allocate(16)) {
-            rs.encodeAsByteBuf(buffer);
+            rs.encodeAsBuffer(buffer);
 
             buffer.readerOffset(0);
             assertEquals(SocksProtocolVersion.SOCKS5.byteValue(), buffer.readByte());
@@ -142,7 +142,7 @@ public class SocksCmdResponseTest {
         assertEquals(host, rs.host());
 
         try (Buffer buffer = preferredAllocator().allocate(32)) {
-            rs.encodeAsByteBuf(buffer);
+            rs.encodeAsBuffer(buffer);
 
             buffer.readerOffset(0);
             assertEquals(SocksProtocolVersion.SOCKS5.byteValue(), buffer.readByte());

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCmdResponseTest.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCmdResponseTest.java
@@ -57,7 +57,7 @@ public class SocksCmdResponseTest {
                     0x00, // port value
                     0x00
             };
-            assertByteBufEquals(expected, buffer);
+            assertBufferEquals(expected, buffer);
         }
     }
 
@@ -84,7 +84,7 @@ public class SocksCmdResponseTest {
                     0x00, // port
                     0x50
             };
-            assertByteBufEquals(expected, buffer);
+            assertBufferEquals(expected, buffer);
         }
     }
 
@@ -108,7 +108,7 @@ public class SocksCmdResponseTest {
                     0x00, // port
                     0x50
             };
-            assertByteBufEquals(expected, buffer);
+            assertBufferEquals(expected, buffer);
         }
     }
 
@@ -165,7 +165,7 @@ public class SocksCmdResponseTest {
             () -> new SocksCmdResponse(SocksCmdStatus.SUCCESS, SocksAddressType.IPv4, "127.0.0", 1000));
     }
 
-    private static void assertByteBufEquals(byte[] expected, Buffer actual) {
+    private static void assertBufferEquals(byte[] expected, Buffer actual) {
         byte[] actualBytes = new byte[actual.readableBytes()];
         actual.readBytes(actualBytes, 0, actualBytes.length);
         assertEquals(expected.length, actualBytes.length, "Generated response has incorrect length");

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCommonTestUtils.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCommonTestUtils.java
@@ -15,8 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 
 final class SocksCommonTestUtils {
@@ -29,7 +28,7 @@ final class SocksCommonTestUtils {
 
     @SuppressWarnings("deprecation")
     public static void writeMessageIntoEmbedder(EmbeddedChannel embedder, SocksMessage msg) {
-        ByteBuf buf = Unpooled.buffer();
+        Buffer buf = embedder.bufferAllocator().allocate(64);
         msg.encodeAsByteBuf(buf);
         embedder.writeInbound(buf);
     }

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCommonTestUtils.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCommonTestUtils.java
@@ -29,7 +29,7 @@ final class SocksCommonTestUtils {
     @SuppressWarnings("deprecation")
     public static void writeMessageIntoEmbedder(EmbeddedChannel embedder, SocksMessage msg) {
         Buffer buf = embedder.bufferAllocator().allocate(64);
-        msg.encodeAsByteBuf(buf);
+        msg.encodeAsBuffer(buf);
         embedder.writeInbound(buf);
     }
 }

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socksx/v5/DefaultSocks5CommandResponseTest.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socksx/v5/DefaultSocks5CommandResponseTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -42,18 +42,18 @@ public class DefaultSocks5CommandResponseTest {
         assertNull(socks5CmdResponse.bndAddr());
         assertEquals(0, socks5CmdResponse.bndPort());
 
-        ByteBuf buffer = Socks5CommonTestUtils.encodeServer(socks5CmdResponse);
-        byte[] expected = {
-                0x05, // version
-                0x00, // success reply
-                0x00, // reserved
-                0x03, // address type domain
-                0x00, // length of domain
-                0x00, // port value
-                0x00
-        };
-        assertByteBufEquals(expected, buffer);
-        buffer.release();
+        try (Buffer buffer = Socks5CommonTestUtils.encodeServer(socks5CmdResponse)) {
+            byte[] expected = {
+                    0x05, // version
+                    0x00, // success reply
+                    0x00, // reserved
+                    0x03, // address type domain
+                    0x00, // length of domain
+                    0x00, // port value
+                    0x00
+            };
+            assertByteBufEquals(expected, buffer);
+        }
     }
 
     /**
@@ -66,21 +66,21 @@ public class DefaultSocks5CommandResponseTest {
         assertEquals("127.0.0.1", socks5CmdResponse.bndAddr());
         assertEquals(80, socks5CmdResponse.bndPort());
 
-        ByteBuf buffer = Socks5CommonTestUtils.encodeServer(socks5CmdResponse);
-        byte[] expected = {
-                0x05, // version
-                0x00, // success reply
-                0x00, // reserved
-                0x01, // address type IPv4
-                0x7F, // address 127.0.0.1
-                0x00,
-                0x00,
-                0x01,
-                0x00, // port
-                0x50
-                };
-        assertByteBufEquals(expected, buffer);
-        buffer.release();
+        try (Buffer buffer = Socks5CommonTestUtils.encodeServer(socks5CmdResponse)) {
+            byte[] expected = {
+                    0x05, // version
+                    0x00, // success reply
+                    0x00, // reserved
+                    0x01, // address type IPv4
+                    0x7F, // address 127.0.0.1
+                    0x00,
+                    0x00,
+                    0x01,
+                    0x00, // port
+                    0x50
+            };
+            assertByteBufEquals(expected, buffer);
+        }
     }
 
     /**
@@ -93,18 +93,18 @@ public class DefaultSocks5CommandResponseTest {
         assertEquals("", socks5CmdResponse.bndAddr());
         assertEquals(80, socks5CmdResponse.bndPort());
 
-        ByteBuf buffer = Socks5CommonTestUtils.encodeServer(socks5CmdResponse);
-        byte[] expected = {
-                0x05, // version
-                0x00, // success reply
-                0x00, // reserved
-                0x03, // address type domain
-                0x00, // domain length
-                0x00, // port
-                0x50
-        };
-        assertByteBufEquals(expected, buffer);
-        buffer.release();
+        try (Buffer buffer = Socks5CommonTestUtils.encodeServer(socks5CmdResponse)) {
+            byte[] expected = {
+                    0x05, // version
+                    0x00, // success reply
+                    0x00, // reserved
+                    0x03, // address type domain
+                    0x00, // domain length
+                    0x00, // port
+                    0x50
+            };
+            assertByteBufEquals(expected, buffer);
+        }
     }
 
     /**
@@ -116,9 +116,9 @@ public class DefaultSocks5CommandResponseTest {
                 Socks5CommandStatus.SUCCESS, Socks5AddressType.IPv4, "127.0.0", 1000));
     }
 
-    private static void assertByteBufEquals(byte[] expected, ByteBuf actual) {
+    private static void assertByteBufEquals(byte[] expected, Buffer actual) {
         byte[] actualBytes = new byte[actual.readableBytes()];
-        actual.readBytes(actualBytes);
+        actual.readBytes(actualBytes, 0, actualBytes.length);
         assertEquals(expected.length, actualBytes.length, "Generated response has incorrect length");
         assertArrayEquals(expected, actualBytes, "Generated response differs from expected");
     }

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socksx/v5/DefaultSocks5CommandResponseTest.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socksx/v5/DefaultSocks5CommandResponseTest.java
@@ -52,7 +52,7 @@ public class DefaultSocks5CommandResponseTest {
                     0x00, // port value
                     0x00
             };
-            assertByteBufEquals(expected, buffer);
+            assertBufferEquals(expected, buffer);
         }
     }
 
@@ -79,7 +79,7 @@ public class DefaultSocks5CommandResponseTest {
                     0x00, // port
                     0x50
             };
-            assertByteBufEquals(expected, buffer);
+            assertBufferEquals(expected, buffer);
         }
     }
 
@@ -103,7 +103,7 @@ public class DefaultSocks5CommandResponseTest {
                     0x00, // port
                     0x50
             };
-            assertByteBufEquals(expected, buffer);
+            assertBufferEquals(expected, buffer);
         }
     }
 
@@ -116,7 +116,7 @@ public class DefaultSocks5CommandResponseTest {
                 Socks5CommandStatus.SUCCESS, Socks5AddressType.IPv4, "127.0.0", 1000));
     }
 
-    private static void assertByteBufEquals(byte[] expected, Buffer actual) {
+    private static void assertBufferEquals(byte[] expected, Buffer actual) {
         byte[] actualBytes = new byte[actual.readableBytes()];
         actual.readBytes(actualBytes, 0, actualBytes.length);
         assertEquals(expected.length, actualBytes.length, "Generated response has incorrect length");

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socksx/v5/Socks5CommonTestUtils.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socksx/v5/Socks5CommonTestUtils.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 
 final class Socks5CommonTestUtils {
@@ -34,21 +34,21 @@ final class Socks5CommonTestUtils {
         embedder.writeInbound(encodeServer(msg));
     }
 
-    public static ByteBuf encodeClient(Socks5Message msg) {
+    public static Buffer encodeClient(Socks5Message msg) {
         EmbeddedChannel out = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
         out.writeOutbound(msg);
 
-        ByteBuf encoded = out.readOutbound();
+        Buffer encoded = out.readOutbound();
         out.finish();
 
         return encoded;
     }
 
-    public static ByteBuf encodeServer(Socks5Message msg) {
+    public static Buffer encodeServer(Socks5Message msg) {
         EmbeddedChannel out = new EmbeddedChannel(Socks5ServerEncoder.DEFAULT);
         out.writeOutbound(msg);
 
-        ByteBuf encoded = out.readOutbound();
+        Buffer encoded = out.readOutbound();
         out.finish();
 
         return encoded;

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socksx/v5/Socks5InitialRequestDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socksx/v5/Socks5InitialRequestDecoderTest.java
@@ -15,7 +15,6 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty.buffer.Unpooled;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.DecoderResult;
 import org.junit.jupiter.api.Test;
@@ -28,8 +27,8 @@ public class Socks5InitialRequestDecoderTest {
     @Test
     public void testUnpackingCausesDecodeFail() {
         EmbeddedChannel e = new EmbeddedChannel(new Socks5InitialRequestDecoder());
-        assertFalse(e.writeInbound(Unpooled.wrappedBuffer(new byte[]{5, 2, 0})));
-        assertTrue(e.writeInbound(Unpooled.wrappedBuffer(new byte[]{1})));
+        assertFalse(e.writeInbound(e.bufferAllocator().copyOf(new byte[]{5, 2, 0})));
+        assertTrue(e.writeInbound(e.bufferAllocator().copyOf(new byte[]{1})));
         Object o = e.readInbound();
 
         assertTrue(o instanceof DefaultSocks5InitialRequest);

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/RelayHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/RelayHandler.java
@@ -15,7 +15,6 @@
  */
 package io.netty.contrib.handler.codec.example.socksproxy;
 
-import io.netty.buffer.Unpooled;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
@@ -31,7 +30,7 @@ public final class RelayHandler implements ChannelHandler {
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) {
-        ctx.writeAndFlush(Unpooled.EMPTY_BUFFER);
+        ctx.writeAndFlush(ctx.bufferAllocator().allocate(0));
     }
 
     @Override

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/SocksServerUtils.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/SocksServerUtils.java
@@ -15,7 +15,6 @@
  */
 package io.netty.contrib.handler.codec.example.socksproxy;
 
-import io.netty.buffer.Unpooled;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelFutureListeners;
 
@@ -26,7 +25,7 @@ public final class SocksServerUtils {
      */
     public static void closeOnFlush(Channel ch) {
         if (ch.isActive()) {
-            ch.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ch, ChannelFutureListeners.CLOSE);
+            ch.writeAndFlush(ch.bufferAllocator().allocate(0)).addListener(ch, ChannelFutureListeners.CLOSE);
         }
     }
 

--- a/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/HttpProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/HttpProxyHandler.java
@@ -38,7 +38,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 
-import static io.netty5.handler.adaptor.BufferConversionHandler.byteBufToBuffer;
 import static java.util.Objects.requireNonNull;
 
 public final class HttpProxyHandler extends ProxyHandler {
@@ -134,7 +133,6 @@ public final class HttpProxyHandler extends ProxyHandler {
     protected void addCodec(ChannelHandlerContext ctx) throws Exception {
         ChannelPipeline p = ctx.pipeline();
         String name = ctx.name();
-        p.addBefore(name, null, byteBufToBuffer());
         p.addBefore(name, null, codecWrapper);
     }
 

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyHandlerTest.java
@@ -16,9 +16,7 @@
 package io.netty.contrib.handler.proxy;
 
 import io.netty5.bootstrap.Bootstrap;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.PooledByteBufAllocator;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
@@ -63,6 +61,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import static io.netty5.buffer.ByteBufUtil.writeAscii;
+import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -194,57 +194,57 @@ public class ProxyHandlerTest {
                         "Anonymous HTTPS proxy: successful connection, AUTO_READ on",
                         DESTINATION,
                         true,
-                        clientSslCtx.newHandler(PooledByteBufAllocator.DEFAULT),
+                        clientSslCtx.newHandler(preferredAllocator()),
                         new HttpProxyHandler(anonHttpsProxy.address())),
 
                 new SuccessTestItem(
                         "Anonymous HTTPS proxy: successful connection, AUTO_READ off",
                         DESTINATION,
                         false,
-                        clientSslCtx.newHandler(PooledByteBufAllocator.DEFAULT),
+                        clientSslCtx.newHandler(preferredAllocator()),
                         new HttpProxyHandler(anonHttpsProxy.address())),
 
                 new FailureTestItem(
                         "Anonymous HTTPS proxy: rejected connection",
                         BAD_DESTINATION, "status: 403",
-                        clientSslCtx.newHandler(PooledByteBufAllocator.DEFAULT),
+                        clientSslCtx.newHandler(preferredAllocator()),
                         new HttpProxyHandler(anonHttpsProxy.address())),
 
                 new FailureTestItem(
                         "HTTPS proxy: rejected anonymous connection",
                         DESTINATION, "status: 401",
-                        clientSslCtx.newHandler(PooledByteBufAllocator.DEFAULT),
+                        clientSslCtx.newHandler(preferredAllocator()),
                         new HttpProxyHandler(httpsProxy.address())),
 
                 new SuccessTestItem(
                         "HTTPS proxy: successful connection, AUTO_READ on",
                         DESTINATION,
                         true,
-                        clientSslCtx.newHandler(PooledByteBufAllocator.DEFAULT),
+                        clientSslCtx.newHandler(preferredAllocator()),
                         new HttpProxyHandler(httpsProxy.address(), USERNAME, PASSWORD)),
 
                 new SuccessTestItem(
                         "HTTPS proxy: successful connection, AUTO_READ off",
                         DESTINATION,
                         false,
-                        clientSslCtx.newHandler(PooledByteBufAllocator.DEFAULT),
+                        clientSslCtx.newHandler(preferredAllocator()),
                         new HttpProxyHandler(httpsProxy.address(), USERNAME, PASSWORD)),
 
                 new FailureTestItem(
                         "HTTPS proxy: rejected connection",
                         BAD_DESTINATION, "status: 403",
-                        clientSslCtx.newHandler(PooledByteBufAllocator.DEFAULT),
+                        clientSslCtx.newHandler(preferredAllocator()),
                         new HttpProxyHandler(httpsProxy.address(), USERNAME, PASSWORD)),
 
                 new FailureTestItem(
                         "HTTPS proxy: authentication failure",
                         DESTINATION, "status: 401",
-                        clientSslCtx.newHandler(PooledByteBufAllocator.DEFAULT),
+                        clientSslCtx.newHandler(preferredAllocator()),
                         new HttpProxyHandler(httpsProxy.address(), BAD_USERNAME, BAD_PASSWORD)),
 
                 new TimeoutTestItem(
                         "HTTPS proxy: timeout",
-                        clientSslCtx.newHandler(PooledByteBufAllocator.DEFAULT),
+                        clientSslCtx.newHandler(preferredAllocator()),
                         new HttpProxyHandler(deadHttpsProxy.address())),
 
                 // SOCKS4 -----------------------------------------------------
@@ -355,7 +355,7 @@ public class ProxyHandlerTest {
                         true,
                         new Socks5ProxyHandler(interSocks5Proxy.address()), // SOCKS5
                         new Socks4ProxyHandler(interSocks4Proxy.address()), // SOCKS4
-                        clientSslCtx.newHandler(PooledByteBufAllocator.DEFAULT),
+                        clientSslCtx.newHandler(preferredAllocator()),
                         new HttpProxyHandler(interHttpsProxy.address()), // HTTPS
                         new HttpProxyHandler(interHttpProxy.address()), // HTTP
                         new HttpProxyHandler(anonHttpProxy.address())),
@@ -366,7 +366,7 @@ public class ProxyHandlerTest {
                         false,
                         new Socks5ProxyHandler(interSocks5Proxy.address()), // SOCKS5
                         new Socks4ProxyHandler(interSocks4Proxy.address()), // SOCKS4
-                        clientSslCtx.newHandler(PooledByteBufAllocator.DEFAULT),
+                        clientSslCtx.newHandler(preferredAllocator()),
                         new HttpProxyHandler(interHttpsProxy.address()), // HTTPS
                         new HttpProxyHandler(interHttpProxy.address()), // HTTP
                         new HttpProxyHandler(anonHttpProxy.address())),
@@ -379,12 +379,12 @@ public class ProxyHandlerTest {
                         true,
                         new Socks5ProxyHandler(interSocks5Proxy.address()), // SOCKS5
                         new Socks4ProxyHandler(interSocks4Proxy.address()), // SOCKS4
-                        clientSslCtx.newHandler(PooledByteBufAllocator.DEFAULT),
+                        clientSslCtx.newHandler(preferredAllocator()),
                         new HttpProxyHandler(interHttpsProxy.address()), // HTTPS
                         new HttpProxyHandler(interHttpProxy.address()), // HTTP
                         new Socks5ProxyHandler(interSocks5Proxy.address()), // SOCKS5
                         new Socks4ProxyHandler(interSocks4Proxy.address()), // SOCKS4
-                        clientSslCtx.newHandler(PooledByteBufAllocator.DEFAULT),
+                        clientSslCtx.newHandler(preferredAllocator()),
                         new HttpProxyHandler(interHttpsProxy.address()), // HTTPS
                         new HttpProxyHandler(interHttpProxy.address()), // HTTP
                         new HttpProxyHandler(anonHttpProxy.address())),
@@ -395,12 +395,12 @@ public class ProxyHandlerTest {
                         false,
                         new Socks5ProxyHandler(interSocks5Proxy.address()), // SOCKS5
                         new Socks4ProxyHandler(interSocks4Proxy.address()), // SOCKS4
-                        clientSslCtx.newHandler(PooledByteBufAllocator.DEFAULT),
+                        clientSslCtx.newHandler(preferredAllocator()),
                         new HttpProxyHandler(interHttpsProxy.address()), // HTTPS
                         new HttpProxyHandler(interHttpProxy.address()), // HTTP
                         new Socks5ProxyHandler(interSocks5Proxy.address()), // SOCKS5
                         new Socks4ProxyHandler(interSocks4Proxy.address()), // SOCKS4
-                        clientSslCtx.newHandler(PooledByteBufAllocator.DEFAULT),
+                        clientSslCtx.newHandler(preferredAllocator()),
                         new HttpProxyHandler(interHttpsProxy.address()), // HTTPS
                         new HttpProxyHandler(interHttpProxy.address()), // HTTP
                         new HttpProxyHandler(anonHttpProxy.address()))
@@ -428,7 +428,7 @@ public class ProxyHandlerTest {
     }
 
     @BeforeEach
-    public void clearServerExceptions() throws Exception {
+    public void clearServerExceptions() {
         for (ProxyServer p: allProxies) {
             p.clearExceptions();
         }
@@ -441,7 +441,7 @@ public class ProxyHandlerTest {
     }
 
     @AfterEach
-    public void checkServerExceptions() throws Exception {
+    public void checkServerExceptions() {
         for (ProxyServer p: allProxies) {
             p.checkExceptions();
         }
@@ -460,37 +460,37 @@ public class ProxyHandlerTest {
         }
 
         @Override
-        public void channelActive(ChannelHandlerContext ctx) throws Exception {
-            ctx.writeAndFlush(Unpooled.copiedBuffer("A\n", CharsetUtil.US_ASCII));
+        public void channelActive(ChannelHandlerContext ctx) {
+            ctx.writeAndFlush(writeAscii(ctx.bufferAllocator(), "A\n"));
             readIfNeeded(ctx);
         }
 
         @Override
-        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
             if (evt instanceof ProxyConnectionEvent) {
                 eventCount ++;
 
                 if (eventCount == 1) {
                     // Note that ProxyConnectionEvent can be triggered multiple times when there are multiple
                     // ProxyHandlers in the pipeline.  Therefore, we send the 'B' message only on the first event.
-                    ctx.writeAndFlush(Unpooled.copiedBuffer("B\n", CharsetUtil.US_ASCII));
+                    ctx.writeAndFlush(writeAscii(ctx.bufferAllocator(), "B\n"));
                 }
                 readIfNeeded(ctx);
             }
         }
 
         @Override
-        protected void messageReceived(ChannelHandlerContext ctx, Object msg) throws Exception {
-            String str = ((ByteBuf) msg).toString(CharsetUtil.US_ASCII);
+        protected void messageReceived(ChannelHandlerContext ctx, Object msg) {
+            String str = ((Buffer) msg).toString(CharsetUtil.US_ASCII);
             received.add(str);
             if ("2".equals(str)) {
-                ctx.writeAndFlush(Unpooled.copiedBuffer("C\n", CharsetUtil.US_ASCII));
+                ctx.writeAndFlush(writeAscii(ctx.bufferAllocator(), "C\n"));
             }
             readIfNeeded(ctx);
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
             exceptions.add(cause);
             ctx.close();
         }
@@ -510,8 +510,8 @@ public class ProxyHandlerTest {
         final CountDownLatch latch = new CountDownLatch(2);
 
         @Override
-        public void channelActive(ChannelHandlerContext ctx) throws Exception {
-            ctx.writeAndFlush(Unpooled.copiedBuffer("A\n", CharsetUtil.US_ASCII)).addListener(
+        public void channelActive(ChannelHandlerContext ctx) {
+            ctx.writeAndFlush(writeAscii(ctx.bufferAllocator(), "A\n")).addListener(
                     future -> {
                         latch.countDown();
                         if (!(future.cause() instanceof ProxyConnectException)) {
@@ -522,24 +522,24 @@ public class ProxyHandlerTest {
         }
 
         @Override
-        public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        public void channelInactive(ChannelHandlerContext ctx) {
             latch.countDown();
         }
 
         @Override
-        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
             if (evt instanceof ProxyConnectionEvent) {
                 fail("Unexpected event: " + evt);
             }
         }
 
         @Override
-        protected void messageReceived(ChannelHandlerContext ctx, Object msg) throws Exception {
+        protected void messageReceived(ChannelHandlerContext ctx, Object msg) {
             fail("Unexpected message: " + msg);
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
             exceptions.add(cause);
             ctx.close();
         }
@@ -632,7 +632,7 @@ public class ProxyHandlerTest {
             b.resolver(NoopAddressResolverGroup.INSTANCE);
             b.handler(new ChannelInitializer<SocketChannel>() {
                 @Override
-                protected void initChannel(SocketChannel ch) throws Exception {
+                protected void initChannel(SocketChannel ch) {
                     ChannelPipeline p = ch.pipeline();
                     p.addLast(clientHandlers);
                     p.addLast(new LineBasedFrameDecoder(64));
@@ -681,7 +681,7 @@ public class ProxyHandlerTest {
             b.resolver(NoopAddressResolverGroup.INSTANCE);
             b.handler(new ChannelInitializer<SocketChannel>() {
                 @Override
-                protected void initChannel(SocketChannel ch) throws Exception {
+                protected void initChannel(SocketChannel ch) {
                     ChannelPipeline p = ch.pipeline();
                     p.addLast(clientHandlers);
                     p.addLast(new LineBasedFrameDecoder(64));
@@ -727,7 +727,7 @@ public class ProxyHandlerTest {
             b.resolver(NoopAddressResolverGroup.INSTANCE);
             b.handler(new ChannelInitializer<SocketChannel>() {
                 @Override
-                protected void initChannel(SocketChannel ch) throws Exception {
+                protected void initChannel(SocketChannel ch) {
                     ChannelPipeline p = ch.pipeline();
                     p.addLast(clientHandlers);
                     p.addLast(new LineBasedFrameDecoder(64));

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/Socks4ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/Socks4ProxyServer.java
@@ -15,7 +15,6 @@
  */
 package io.netty.contrib.handler.proxy;
 
-import io.netty.buffer.Unpooled;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.socket.SocketChannel;
@@ -33,6 +32,7 @@ import io.netty5.util.internal.SocketUtils;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
+import static io.netty5.buffer.ByteBufUtil.writeAscii;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class Socks4ProxyServer extends ProxyServer {
@@ -46,7 +46,7 @@ final class Socks4ProxyServer extends ProxyServer {
     }
 
     @Override
-    protected void configure(SocketChannel ch) throws Exception {
+    protected void configure(SocketChannel ch) {
         ChannelPipeline p = ch.pipeline();
         switch (testMode) {
         case INTERMEDIARY:
@@ -86,7 +86,7 @@ final class Socks4ProxyServer extends ProxyServer {
         private SocketAddress intermediaryDestination;
 
         @Override
-        protected boolean handleProxyProtocol(ChannelHandlerContext ctx, Object msg) throws Exception {
+        protected boolean handleProxyProtocol(ChannelHandlerContext ctx, Object msg) {
             Socks4CommandRequest req = (Socks4CommandRequest) msg;
             Socks4CommandResponse res;
 
@@ -113,7 +113,7 @@ final class Socks4ProxyServer extends ProxyServer {
 
     private final class Socks4TerminalHandler extends TerminalHandler {
         @Override
-        protected boolean handleProxyProtocol(ChannelHandlerContext ctx, Object msg) throws Exception {
+        protected boolean handleProxyProtocol(ChannelHandlerContext ctx, Object msg) {
             Socks4CommandRequest req = (Socks4CommandRequest) msg;
             boolean authzSuccess = authenticate(ctx, req);
 
@@ -135,7 +135,7 @@ final class Socks4ProxyServer extends ProxyServer {
             ctx.pipeline().remove(Socks4ServerEncoder.class);
 
             if (sendGreeting) {
-                ctx.write(Unpooled.copiedBuffer("0\n", CharsetUtil.US_ASCII));
+                ctx.write(writeAscii(ctx.bufferAllocator(), "0\n"));
             }
 
             return true;

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/Socks5ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/Socks5ProxyServer.java
@@ -15,7 +15,6 @@
  */
 package io.netty.contrib.handler.proxy;
 
-import io.netty.buffer.Unpooled;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.socket.SocketChannel;
@@ -42,6 +41,7 @@ import io.netty5.util.internal.SocketUtils;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
+import static io.netty5.buffer.ByteBufUtil.writeAscii;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class Socks5ProxyServer extends ProxyServer {
@@ -59,7 +59,7 @@ final class Socks5ProxyServer extends ProxyServer {
     }
 
     @Override
-    protected void configure(SocketChannel ch) throws Exception {
+    protected void configure(SocketChannel ch) {
         ChannelPipeline p = ch.pipeline();
         switch (testMode) {
         case INTERMEDIARY:
@@ -109,7 +109,7 @@ final class Socks5ProxyServer extends ProxyServer {
         private SocketAddress intermediaryDestination;
 
         @Override
-        protected boolean handleProxyProtocol(ChannelHandlerContext ctx, Object msg) throws Exception {
+        protected boolean handleProxyProtocol(ChannelHandlerContext ctx, Object msg) {
             if (!authenticated) {
                 authenticated = authenticate(ctx, msg);
                 return false;
@@ -141,7 +141,7 @@ final class Socks5ProxyServer extends ProxyServer {
         private boolean authenticated;
 
         @Override
-        protected boolean handleProxyProtocol(ChannelHandlerContext ctx, Object msg) throws Exception {
+        protected boolean handleProxyProtocol(ChannelHandlerContext ctx, Object msg) {
             if (!authenticated) {
                 authenticated = authenticate(ctx, msg);
                 return false;
@@ -168,7 +168,7 @@ final class Socks5ProxyServer extends ProxyServer {
             ctx.pipeline().remove(DECODER);
 
             if (sendGreeting) {
-                ctx.write(Unpooled.copiedBuffer("0\n", CharsetUtil.US_ASCII));
+                ctx.write(writeAscii(ctx.bufferAllocator(), "0\n"));
             }
 
             return true;


### PR DESCRIPTION
Motivation:

Helps to have a pipeline working only with `Buffer` API

Modifications:

- Port `socks-proxy` to `Buffer` API
- When creating `SslHandler`, `BufferAllocator` is used
- Remove the usage of `ByteBufToBuffer` handler
- Adapt the junit tests

Result:

`socks-proxy` now is using the `Buffer` API