### PR TITLE
Update to Netty 5.0.0.Alpha3-SNAPSHOT changes

### DIFF
--- a/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/HttpProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/HttpProxyHandler.java
@@ -18,6 +18,7 @@ package io.netty.contrib.handler.proxy;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
+import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.handler.codec.http.DefaultFullHttpRequest;
 import io.netty5.handler.codec.http.FullHttpRequest;
 import io.netty5.handler.codec.http.HttpClientCodec;
@@ -263,6 +264,11 @@ public final class HttpProxyHandler extends ProxyHandler {
         }
 
         @Override
+        public void channelShutdown(ChannelHandlerContext ctx, ChannelShutdownDirection direction) throws Exception {
+            codec.channelShutdown(ctx, direction);
+        }
+
+        @Override
         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
             codec.channelRead(ctx, msg);
         }
@@ -273,8 +279,8 @@ public final class HttpProxyHandler extends ProxyHandler {
         }
 
         @Override
-        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-            codec.userEventTriggered(ctx, evt);
+        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            codec.inboundEventTriggered(ctx, evt);
         }
 
         @Override
@@ -304,6 +310,16 @@ public final class HttpProxyHandler extends ProxyHandler {
         }
 
         @Override
+        public Future<Void> shutdown(ChannelHandlerContext ctx, ChannelShutdownDirection direction) {
+            return codec.shutdown(ctx, direction);
+        }
+
+        @Override
+        public Future<Void> register(ChannelHandlerContext ctx) {
+            return codec.register(ctx);
+        }
+
+        @Override
         public Future<Void> deregister(ChannelHandlerContext ctx) {
             return codec.deregister(ctx);
         }
@@ -321,6 +337,11 @@ public final class HttpProxyHandler extends ProxyHandler {
         @Override
         public void flush(ChannelHandlerContext ctx) {
             codec.flush(ctx);
+        }
+
+        @Override
+        public Future<Void> triggerOutboundEvent(ChannelHandlerContext ctx, Object event) {
+            return codec.triggerOutboundEvent(ctx, event);
         }
     }
 }

--- a/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/ProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/ProxyHandler.java
@@ -278,7 +278,7 @@ public abstract class ProxyHandler implements ChannelHandler {
 
             removedCodec &= safeRemoveEncoder();
 
-            ctx.fireUserEventTriggered(
+            ctx.fireInboundEventTriggered(
                     new ProxyConnectionEvent(protocol(), authScheme(), proxyAddress, destinationAddress));
 
             removedCodec &= safeRemoveDecoder();

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/HttpProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/HttpProxyServer.java
@@ -42,12 +42,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 final class HttpProxyServer extends ProxyServer {
 
-    HttpProxyServer(boolean useSsl, TestMode testMode, InetSocketAddress destination) {
+    HttpProxyServer(boolean useSsl, TestMode testMode, InetSocketAddress destination) throws InterruptedException {
         super(useSsl, testMode, destination);
     }
 
     HttpProxyServer(
-            boolean useSsl, TestMode testMode, InetSocketAddress destination, String username, String password) {
+            boolean useSsl, TestMode testMode, InetSocketAddress destination, String username, String password)
+            throws InterruptedException {
         super(useSsl, testMode, destination, username, password);
     }
 

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyHandlerTest.java
@@ -44,6 +44,7 @@ import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -100,36 +101,53 @@ public class ProxyHandlerTest {
         clientSslCtx = cctx;
     }
 
-    static final ProxyServer deadHttpProxy = new HttpProxyServer(false, TestMode.UNRESPONSIVE, null);
-    static final ProxyServer interHttpProxy = new HttpProxyServer(false, TestMode.INTERMEDIARY, null);
-    static final ProxyServer anonHttpProxy = new HttpProxyServer(false, TestMode.TERMINAL, DESTINATION);
-    static final ProxyServer httpProxy =
-            new HttpProxyServer(false, TestMode.TERMINAL, DESTINATION, USERNAME, PASSWORD);
+    static ProxyServer deadHttpProxy;
+    static ProxyServer interHttpProxy;
+    static ProxyServer anonHttpProxy;
+    static ProxyServer httpProxy;
+    static ProxyServer deadHttpsProxy;
+    static ProxyServer interHttpsProxy;
+    static ProxyServer anonHttpsProxy;
+    static ProxyServer httpsProxy;
+    static ProxyServer deadSocks4Proxy;
+    static ProxyServer interSocks4Proxy;
+    static ProxyServer anonSocks4Proxy;
+    static ProxyServer socks4Proxy;
+    static ProxyServer deadSocks5Proxy;
+    static ProxyServer interSocks5Proxy;
+    static ProxyServer anonSocks5Proxy;
+    static ProxyServer socks5Proxy;
+    private static Collection<ProxyServer> allProxies;
 
-    static final ProxyServer deadHttpsProxy = new HttpProxyServer(true, TestMode.UNRESPONSIVE, null);
-    static final ProxyServer interHttpsProxy = new HttpProxyServer(true, TestMode.INTERMEDIARY, null);
-    static final ProxyServer anonHttpsProxy = new HttpProxyServer(true, TestMode.TERMINAL, DESTINATION);
-    static final ProxyServer httpsProxy =
-            new HttpProxyServer(true, TestMode.TERMINAL, DESTINATION, USERNAME, PASSWORD);
+    @BeforeAll
+    public static void startServers() throws InterruptedException {
+        deadHttpProxy = new HttpProxyServer(false, TestMode.UNRESPONSIVE, null);
+        interHttpProxy = new HttpProxyServer(false, TestMode.INTERMEDIARY, null);
+        anonHttpProxy = new HttpProxyServer(false, TestMode.TERMINAL, DESTINATION);
+        httpProxy = new HttpProxyServer(false, TestMode.TERMINAL, DESTINATION, USERNAME, PASSWORD);
 
-    static final ProxyServer deadSocks4Proxy = new Socks4ProxyServer(false, TestMode.UNRESPONSIVE, null);
-    static final ProxyServer interSocks4Proxy = new Socks4ProxyServer(false, TestMode.INTERMEDIARY, null);
-    static final ProxyServer anonSocks4Proxy = new Socks4ProxyServer(false, TestMode.TERMINAL, DESTINATION);
-    static final ProxyServer socks4Proxy = new Socks4ProxyServer(false, TestMode.TERMINAL, DESTINATION, USERNAME);
+        deadHttpsProxy = new HttpProxyServer(true, TestMode.UNRESPONSIVE, null);
+        interHttpsProxy = new HttpProxyServer(true, TestMode.INTERMEDIARY, null);
+        anonHttpsProxy = new HttpProxyServer(true, TestMode.TERMINAL, DESTINATION);
+        httpsProxy = new HttpProxyServer(true, TestMode.TERMINAL, DESTINATION, USERNAME, PASSWORD);
 
-    static final ProxyServer deadSocks5Proxy = new Socks5ProxyServer(false, TestMode.UNRESPONSIVE, null);
-    static final ProxyServer interSocks5Proxy = new Socks5ProxyServer(false, TestMode.INTERMEDIARY, null);
-    static final ProxyServer anonSocks5Proxy = new Socks5ProxyServer(false, TestMode.TERMINAL, DESTINATION);
-    static final ProxyServer socks5Proxy =
-            new Socks5ProxyServer(false, TestMode.TERMINAL, DESTINATION, USERNAME, PASSWORD);
+        deadSocks4Proxy = new Socks4ProxyServer(false, TestMode.UNRESPONSIVE, null);
+        interSocks4Proxy = new Socks4ProxyServer(false, TestMode.INTERMEDIARY, null);
+        anonSocks4Proxy = new Socks4ProxyServer(false, TestMode.TERMINAL, DESTINATION);
+        socks4Proxy = new Socks4ProxyServer(false, TestMode.TERMINAL, DESTINATION, USERNAME);
 
-    private static final Collection<ProxyServer> allProxies = Arrays.asList(
-            deadHttpProxy, interHttpProxy, anonHttpProxy, httpProxy,
-            deadHttpsProxy, interHttpsProxy, anonHttpsProxy, httpsProxy,
-            deadSocks4Proxy, interSocks4Proxy, anonSocks4Proxy, socks4Proxy,
-            deadSocks5Proxy, interSocks5Proxy, anonSocks5Proxy, socks5Proxy
-    );
+        deadSocks5Proxy = new Socks5ProxyServer(false, TestMode.UNRESPONSIVE, null);
+        interSocks5Proxy = new Socks5ProxyServer(false, TestMode.INTERMEDIARY, null);
+        anonSocks5Proxy = new Socks5ProxyServer(false, TestMode.TERMINAL, DESTINATION);
+        socks5Proxy = new Socks5ProxyServer(false, TestMode.TERMINAL, DESTINATION, USERNAME, PASSWORD);
 
+        allProxies = Arrays.asList(
+                deadHttpProxy, interHttpProxy, anonHttpProxy, httpProxy,
+                deadHttpsProxy, interHttpsProxy, anonHttpsProxy, httpsProxy,
+                deadSocks4Proxy, interSocks4Proxy, anonSocks4Proxy, socks4Proxy,
+                deadSocks5Proxy, interSocks5Proxy, anonSocks5Proxy, socks5Proxy
+        );
+    }
     // set to non-zero value in case you need predictable shuffling of test cases
     // look for "Seed used: *" debug message in test logs
     private static final long reproducibleSeed = 0L;
@@ -466,7 +484,7 @@ public class ProxyHandlerTest {
         }
 
         @Override
-        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
             if (evt instanceof ProxyConnectionEvent) {
                 eventCount ++;
 
@@ -527,7 +545,7 @@ public class ProxyHandlerTest {
         }
 
         @Override
-        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
             if (evt instanceof ProxyConnectionEvent) {
                 fail("Unexpected event: " + evt);
             }

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyServer.java
@@ -65,7 +65,8 @@ abstract class ProxyServer {
      * @param destination the expected destination. If the client requests proxying to a different destination, this
      * server will reject the connection request.
      */
-    protected ProxyServer(boolean useSsl, TestMode testMode, InetSocketAddress destination) {
+    protected ProxyServer(boolean useSsl, TestMode testMode, InetSocketAddress destination)
+            throws InterruptedException {
         this(useSsl, testMode, destination, null, null);
     }
 
@@ -83,7 +84,7 @@ abstract class ProxyServer {
      */
     protected ProxyServer(
             final boolean useSsl, TestMode testMode,
-            InetSocketAddress destination, String username, String password) {
+            InetSocketAddress destination, String username, String password) throws InterruptedException {
 
         this.testMode = testMode;
         this.destination = destination;
@@ -105,7 +106,7 @@ abstract class ProxyServer {
             }
         });
 
-        ch = (ServerSocketChannel) b.bind(NetUtil.LOCALHOST, 0).syncUninterruptibly().getNow();
+        ch = (ServerSocketChannel) b.bind(NetUtil.LOCALHOST, 0).sync().getNow();
     }
 
     public final InetSocketAddress address() {

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/Socks4ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/Socks4ProxyServer.java
@@ -36,11 +36,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 final class Socks4ProxyServer extends ProxyServer {
 
-    Socks4ProxyServer(boolean useSsl, TestMode testMode, InetSocketAddress destination) {
+    Socks4ProxyServer(boolean useSsl, TestMode testMode, InetSocketAddress destination) throws InterruptedException {
         super(useSsl, testMode, destination);
     }
 
-    Socks4ProxyServer(boolean useSsl, TestMode testMode, InetSocketAddress destination, String username) {
+    Socks4ProxyServer(boolean useSsl, TestMode testMode, InetSocketAddress destination, String username)
+            throws InterruptedException {
         super(useSsl, testMode, destination, username, null);
     }
 

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/Socks5ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/Socks5ProxyServer.java
@@ -49,12 +49,13 @@ final class Socks5ProxyServer extends ProxyServer {
     private static final String ENCODER = "encoder";
     private static final String DECODER = "decoder";
 
-    Socks5ProxyServer(boolean useSsl, TestMode testMode, InetSocketAddress destination) {
+    Socks5ProxyServer(boolean useSsl, TestMode testMode, InetSocketAddress destination) throws InterruptedException {
         super(useSsl, testMode, destination);
     }
 
     Socks5ProxyServer(
-            boolean useSsl, TestMode testMode, InetSocketAddress destination, String username, String password) {
+            boolean useSsl, TestMode testMode, InetSocketAddress destination, String username, String password)
+            throws InterruptedException {
         super(useSsl, testMode, destination, username, password);
     }
 


### PR DESCRIPTION
Motivation:

The build of the project is broken. This change is adapting the code to the changes in `Netty 5` snapshot.

Modifications:

- Remove the usage of `syncUninterruptibly`. https://github.com/netty/netty/pull/12481
- Adapt to the changes in `ChannelHandler`:
  - `userEventTriggered(...)` is renamed to `inboundEventTriggered(...)`. https://github.com/netty/netty/pull/12497
  - `triggerOutboundEvent(...)` is added. https://github.com/netty/netty/pull/12497
  - `shutdown(...)` and `channelShutdown(...)` are added. https://github.com/netty/netty/pull/12468

Result:

The build of the project is green again