### PR TITLE
Adapt the code to the changes in the ChannelHandler/ChannelHandlerContext methods names

### DIFF
--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/DirectClientHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/DirectClientHandler.java
@@ -35,7 +35,7 @@ public final class DirectClientHandler implements ChannelHandler {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable throwable) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable throwable) {
         promise.setFailure(throwable);
     }
 }

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/RelayHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/RelayHandler.java
@@ -50,7 +50,7 @@ public final class RelayHandler implements ChannelHandler {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/SocksServerConnectHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/SocksServerConnectHandler.java
@@ -126,7 +126,7 @@ public final class SocksServerConnectHandler extends SimpleChannelInboundHandler
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         SocksServerUtils.closeOnFlush(ctx.channel());
     }
 }

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/SocksServerHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/SocksServerHandler.java
@@ -86,7 +86,7 @@ public final class SocksServerHandler extends SimpleChannelInboundHandler<SocksM
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable throwable) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable throwable) {
         throwable.printStackTrace();
         SocksServerUtils.closeOnFlush(ctx.channel());
     }

--- a/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/HttpProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/HttpProxyHandler.java
@@ -239,8 +239,8 @@ public final class HttpProxyHandler extends ProxyHandler {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-            codec.exceptionCaught(ctx, cause);
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            codec.channelExceptionCaught(ctx, cause);
         }
 
         @Override
@@ -279,8 +279,8 @@ public final class HttpProxyHandler extends ProxyHandler {
         }
 
         @Override
-        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-            codec.inboundEventTriggered(ctx, evt);
+        public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) throws Exception {
+            codec.channelInboundEvent(ctx, evt);
         }
 
         @Override
@@ -340,8 +340,8 @@ public final class HttpProxyHandler extends ProxyHandler {
         }
 
         @Override
-        public Future<Void> triggerOutboundEvent(ChannelHandlerContext ctx, Object event) {
-            return codec.triggerOutboundEvent(ctx, event);
+        public Future<Void> sendOutboundEvent(ChannelHandlerContext ctx, Object event) {
+            return codec.sendOutboundEvent(ctx, event);
         }
     }
 }

--- a/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/ProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/ProxyHandler.java
@@ -226,9 +226,9 @@ public abstract class ProxyHandler implements ChannelHandler {
     }
 
     @Override
-    public final void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    public final void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         if (finished) {
-            ctx.fireExceptionCaught(cause);
+            ctx.fireChannelExceptionCaught(cause);
         } else {
             // Exception was raised before the connection attempt is finished.
             setConnectFailure(cause);
@@ -278,7 +278,7 @@ public abstract class ProxyHandler implements ChannelHandler {
 
             removedCodec &= safeRemoveEncoder();
 
-            ctx.fireInboundEventTriggered(
+            ctx.fireChannelInboundEvent(
                     new ProxyConnectionEvent(protocol(), authScheme(), proxyAddress, destinationAddress));
 
             removedCodec &= safeRemoveDecoder();
@@ -341,7 +341,7 @@ public abstract class ProxyHandler implements ChannelHandler {
     private void failPendingWritesAndClose(Throwable cause) {
         failPendingWrites(cause);
         connectPromise.tryFailure(cause);
-        ctx.fireExceptionCaught(cause);
+        ctx.fireChannelExceptionCaught(cause);
         ctx.close();
     }
 

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/HttpProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/HttpProxyHandlerTest.java
@@ -217,7 +217,7 @@ public class HttpProxyHandlerTest {
                         ch.pipeline().addFirst(new HttpProxyHandler(addr));
                         ch.pipeline().addLast(new ChannelHandler() {
                             @Override
-                            public void exceptionCaught(ChannelHandlerContext ctx,
+                            public void channelExceptionCaught(ChannelHandlerContext ctx,
                                 Throwable cause) {
                                 exception.set(cause);
                             }

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyHandlerTest.java
@@ -484,7 +484,7 @@ public class ProxyHandlerTest {
         }
 
         @Override
-        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
             if (evt instanceof ProxyConnectionEvent) {
                 eventCount ++;
 
@@ -508,7 +508,7 @@ public class ProxyHandlerTest {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
             exceptions.add(cause);
             ctx.close();
         }
@@ -545,7 +545,7 @@ public class ProxyHandlerTest {
         }
 
         @Override
-        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
             if (evt instanceof ProxyConnectionEvent) {
                 fail("Unexpected event: " + evt);
             }
@@ -557,7 +557,7 @@ public class ProxyHandlerTest {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
             exceptions.add(cause);
             ctx.close();
         }

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyServer.java
@@ -224,7 +224,7 @@ abstract class ProxyServer {
         }
 
         @Override
-        public final void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        public final void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
             recordException(cause);
             ctx.close();
         }
@@ -253,7 +253,7 @@ abstract class ProxyServer {
             }
 
             @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                 recordException(cause);
                 ctx.close();
             }
@@ -295,7 +295,7 @@ abstract class ProxyServer {
         }
 
         @Override
-        public final void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        public final void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
             recordException(cause);
             ctx.close();
         }


### PR DESCRIPTION
Motivation:

Some of the `ChannelHandler`/`ChannelHandlerContext` methods names are changed with
 https://github.com/netty/netty/pull/12505
The code needs adaptation.

Modifications:

- `fireExceptionCaught(...)` is now `fireChannelExceptionCaught(...)`
- `exceptionCaught(...)` is now `channelExceptionCaught(...)`
- `fireInboundEventTriggered(...)` is now `fireChannelInboundEvent(...)`
- `inboundEventTriggered(...)` is now  `channelInboundEvent(...)`
-  `triggerOutboundEvent(...)` is now `sendOutboundEvent(...)`

Result:

The code is adapted to the new changes in the API.