### PR TITLE
All decoders/encoders now extend ByteToMessageDecoder/MessageToByteEncoder

### DIFF
--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthRequestDecoder.java
@@ -17,14 +17,14 @@ package io.netty.contrib.handler.codec.socks;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
+import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.util.CharsetUtil;
 
 /**
  * Decodes {@link Buffer}s into {@link SocksAuthRequest}.
  * Before returning SocksRequest decoder removes itself from pipeline.
  */
-public class SocksAuthRequestDecoder extends ByteToMessageDecoderForBuffer {
+public class SocksAuthRequestDecoder extends ByteToMessageDecoder {
 
     private enum State {
         CHECK_PROTOCOL_VERSION,

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthResponseDecoder.java
@@ -17,13 +17,13 @@ package io.netty.contrib.handler.codec.socks;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
+import io.netty5.handler.codec.ByteToMessageDecoder;
 
 /**
  * Decodes {@link Buffer}s into {@link SocksAuthResponse}.
  * Before returning SocksResponse decoder removes itself from pipeline.
  */
-public class SocksAuthResponseDecoder extends ByteToMessageDecoderForBuffer {
+public class SocksAuthResponseDecoder extends ByteToMessageDecoder {
 
     private enum State {
         CHECK_PROTOCOL_VERSION,

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdRequestDecoder.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.codec.socks;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
+import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.NetUtil;
 
@@ -25,7 +25,7 @@ import io.netty5.util.NetUtil;
  * Decodes {@link Buffer}s into {@link SocksCmdRequest}.
  * Before returning SocksRequest decoder removes itself from pipeline.
  */
-public class SocksCmdRequestDecoder extends ByteToMessageDecoderForBuffer {
+public class SocksCmdRequestDecoder extends ByteToMessageDecoder {
 
     private enum State {
         CHECK_PROTOCOL_VERSION,

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdResponseDecoder.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.codec.socks;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
+import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.NetUtil;
 
@@ -25,7 +25,7 @@ import io.netty5.util.NetUtil;
  * Decodes {@link Buffer}s into {@link SocksCmdResponse}.
  * Before returning SocksResponse decoder removes itself from pipeline.
  */
-public class SocksCmdResponseDecoder extends ByteToMessageDecoderForBuffer {
+public class SocksCmdResponseDecoder extends ByteToMessageDecoder {
 
     private enum State {
         CHECK_PROTOCOL_VERSION,

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitRequestDecoder.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.codec.socks;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
+import io.netty5.handler.codec.ByteToMessageDecoder;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -27,7 +27,7 @@ import java.util.List;
  * Decodes {@link Buffer}s into {@link SocksInitRequest}.
  * Before returning SocksRequest decoder removes itself from pipeline.
  */
-public class SocksInitRequestDecoder extends ByteToMessageDecoderForBuffer {
+public class SocksInitRequestDecoder extends ByteToMessageDecoder {
 
     private enum State {
         CHECK_PROTOCOL_VERSION,

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitResponseDecoder.java
@@ -17,13 +17,13 @@ package io.netty.contrib.handler.codec.socks;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
+import io.netty5.handler.codec.ByteToMessageDecoder;
 
 /**
  * Decodes {@link Buffer}s into {@link SocksInitResponse}.
  * Before returning SocksResponse decoder removes itself from pipeline.
  */
-public class SocksInitResponseDecoder extends ByteToMessageDecoderForBuffer {
+public class SocksInitResponseDecoder extends ByteToMessageDecoder {
 
     private enum State {
         CHECK_PROTOCOL_VERSION,

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksMessageEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksMessageEncoder.java
@@ -18,16 +18,16 @@ package io.netty.contrib.handler.codec.socks;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.MessageToByteEncoderForBuffer;
+import io.netty5.handler.codec.MessageToByteEncoder;
 
 /**
  * Encodes an {@link SocksMessage} into a {@link Buffer}.
- * {@link MessageToByteEncoderForBuffer} implementation.
+ * {@link MessageToByteEncoder} implementation.
  * Use this with {@link SocksInitRequest}, {@link SocksInitResponse}, {@link SocksAuthRequest},
  * {@link SocksAuthResponse}, {@link SocksCmdRequest} and {@link SocksCmdResponse}
  */
 @ChannelHandler.Sharable
-public class SocksMessageEncoder extends MessageToByteEncoderForBuffer<SocksMessage> {
+public class SocksMessageEncoder extends MessageToByteEncoder<SocksMessage> {
 
     @Override
     protected Buffer allocateBuffer(ChannelHandlerContext ctx, SocksMessage msg) {

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksMessageEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksMessageEncoder.java
@@ -16,7 +16,6 @@
 package io.netty.contrib.handler.codec.socks;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;
 
@@ -26,7 +25,6 @@ import io.netty5.handler.codec.MessageToByteEncoder;
  * Use this with {@link SocksInitRequest}, {@link SocksInitResponse}, {@link SocksAuthRequest},
  * {@link SocksAuthResponse}, {@link SocksCmdRequest} and {@link SocksCmdResponse}
  */
-@ChannelHandler.Sharable
 public class SocksMessageEncoder extends MessageToByteEncoder<SocksMessage> {
 
     @Override
@@ -38,5 +36,10 @@ public class SocksMessageEncoder extends MessageToByteEncoder<SocksMessage> {
     @SuppressWarnings("deprecation")
     protected void encode(ChannelHandlerContext ctx, SocksMessage msg, Buffer out) {
         msg.encodeAsBuffer(out);
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/SocksPortUnificationServerHandler.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/SocksPortUnificationServerHandler.java
@@ -23,7 +23,7 @@ import io.netty.contrib.handler.codec.socksx.v4.Socks4ServerEncoder;
 import io.netty.contrib.handler.codec.socksx.v5.Socks5AddressEncoder;
 import io.netty.contrib.handler.codec.socksx.v5.Socks5InitialRequestDecoder;
 import io.netty.contrib.handler.codec.socksx.v5.Socks5ServerEncoder;
-import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
+import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
 
@@ -33,7 +33,7 @@ import static java.util.Objects.requireNonNull;
  * Detects the version of the current SOCKS connection and initializes the pipeline with
  * {@link Socks4ServerDecoder} or {@link Socks5InitialRequestDecoder}.
  */
-public class SocksPortUnificationServerHandler extends ByteToMessageDecoderForBuffer {
+public class SocksPortUnificationServerHandler extends ByteToMessageDecoder {
 
     private static final InternalLogger logger =
             InternalLoggerFactory.getInstance(SocksPortUnificationServerHandler.class);

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ClientDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ClientDecoder.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.codec.socksx.v4;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
+import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;
 import io.netty5.handler.codec.DecoderResult;
 import io.netty5.util.NetUtil;
@@ -28,7 +28,7 @@ import io.netty5.util.NetUtil;
  * other handler can remove this decoder later.  On failed decode, this decoder will discard the
  * received data, so that other handler closes the connection later.
  */
-public class Socks4ClientDecoder extends ByteToMessageDecoderForBuffer {
+public class Socks4ClientDecoder extends ByteToMessageDecoder {
 
     private enum State {
         START,

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ClientEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ClientEncoder.java
@@ -18,7 +18,7 @@ package io.netty.contrib.handler.codec.socksx.v4;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.MessageToByteEncoderForBuffer;
+import io.netty5.handler.codec.MessageToByteEncoder;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.NetUtil;
 
@@ -26,7 +26,7 @@ import io.netty5.util.NetUtil;
  * Encodes a {@link Socks4CommandRequest} into a {@link Buffer}.
  */
 @Sharable
-public final class Socks4ClientEncoder extends MessageToByteEncoderForBuffer<Socks4CommandRequest> {
+public final class Socks4ClientEncoder extends MessageToByteEncoder<Socks4CommandRequest> {
 
     /**
      * The singleton instance of {@link Socks4ClientEncoder}

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ClientEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ClientEncoder.java
@@ -16,7 +16,6 @@
 package io.netty.contrib.handler.codec.socksx.v4;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;
 import io.netty5.util.CharsetUtil;
@@ -25,7 +24,6 @@ import io.netty5.util.NetUtil;
 /**
  * Encodes a {@link Socks4CommandRequest} into a {@link Buffer}.
  */
-@Sharable
 public final class Socks4ClientEncoder extends MessageToByteEncoder<Socks4CommandRequest> {
 
     /**
@@ -58,5 +56,10 @@ public final class Socks4ClientEncoder extends MessageToByteEncoder<Socks4Comman
             out.writeCharSequence(msg.dstAddr(), CharsetUtil.US_ASCII);
             out.writeByte((byte) 0);
         }
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ServerDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ServerDecoder.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.codec.socksx.v4;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
+import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;
 import io.netty5.handler.codec.DecoderResult;
 import io.netty.contrib.handler.codec.socksx.SocksVersion;
@@ -30,7 +30,7 @@ import io.netty5.util.NetUtil;
  * other handler can remove this decoder later.  On failed decode, this decoder will discard the
  * received data, so that other handler closes the connection later.
  */
-public class Socks4ServerDecoder extends ByteToMessageDecoderForBuffer {
+public class Socks4ServerDecoder extends ByteToMessageDecoder {
 
     private static final int MAX_FIELD_LENGTH = 255;
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ServerEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ServerEncoder.java
@@ -16,7 +16,6 @@
 package io.netty.contrib.handler.codec.socksx.v4;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;
 import io.netty5.util.NetUtil;
@@ -24,7 +23,6 @@ import io.netty5.util.NetUtil;
 /**
  * Encodes a {@link Socks4CommandResponse} into a {@link Buffer}.
  */
-@Sharable
 public final class Socks4ServerEncoder extends MessageToByteEncoder<Socks4CommandResponse> {
 
     public static final Socks4ServerEncoder INSTANCE = new Socks4ServerEncoder();
@@ -45,5 +43,10 @@ public final class Socks4ServerEncoder extends MessageToByteEncoder<Socks4Comman
         out.writeShort((short) msg.dstPort());
         out.writeBytes(msg.dstAddr() == null? IPv4_HOSTNAME_ZEROED
                                             : NetUtil.createByteArrayFromIpAddressString(msg.dstAddr()));
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ServerEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ServerEncoder.java
@@ -18,14 +18,14 @@ package io.netty.contrib.handler.codec.socksx.v4;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.MessageToByteEncoderForBuffer;
+import io.netty5.handler.codec.MessageToByteEncoder;
 import io.netty5.util.NetUtil;
 
 /**
  * Encodes a {@link Socks4CommandResponse} into a {@link Buffer}.
  */
 @Sharable
-public final class Socks4ServerEncoder extends MessageToByteEncoderForBuffer<Socks4CommandResponse> {
+public final class Socks4ServerEncoder extends MessageToByteEncoder<Socks4CommandResponse> {
 
     public static final Socks4ServerEncoder INSTANCE = new Socks4ServerEncoder();
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5ClientEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5ClientEncoder.java
@@ -19,7 +19,7 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.EncoderException;
-import io.netty5.handler.codec.MessageToByteEncoderForBuffer;
+import io.netty5.handler.codec.MessageToByteEncoder;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.internal.StringUtil;
 
@@ -32,7 +32,7 @@ import static java.util.Objects.requireNonNull;
  * Encodes a client-side {@link Socks5Message} into a {@link Buffer}.
  */
 @Sharable
-public class Socks5ClientEncoder extends MessageToByteEncoderForBuffer<Socks5Message> {
+public class Socks5ClientEncoder extends MessageToByteEncoder<Socks5Message> {
 
     public static final Socks5ClientEncoder DEFAULT = new Socks5ClientEncoder();
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5ClientEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5ClientEncoder.java
@@ -16,7 +16,6 @@
 package io.netty.contrib.handler.codec.socksx.v5;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.EncoderException;
 import io.netty5.handler.codec.MessageToByteEncoder;
@@ -31,7 +30,6 @@ import static java.util.Objects.requireNonNull;
 /**
  * Encodes a client-side {@link Socks5Message} into a {@link Buffer}.
  */
-@Sharable
 public class Socks5ClientEncoder extends MessageToByteEncoder<Socks5Message> {
 
     public static final Socks5ClientEncoder DEFAULT = new Socks5ClientEncoder();
@@ -118,5 +116,10 @@ public class Socks5ClientEncoder extends MessageToByteEncoder<Socks5Message> {
         out.writeByte(dstAddrType.byteValue());
         addressEncoder.encodeAddress(dstAddrType, msg.dstAddr(), out);
         out.writeShort((short) msg.dstPort());
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5CommandRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5CommandRequestDecoder.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.codec.socksx.v5;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
+import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;
 import io.netty5.handler.codec.DecoderResult;
 import io.netty.contrib.handler.codec.socksx.SocksVersion;
@@ -30,7 +30,7 @@ import static java.util.Objects.requireNonNull;
  * other handler can remove or replace this decoder later.  On failed decode, this decoder will
  * discard the received data, so that other handler closes the connection later.
  */
-public class Socks5CommandRequestDecoder extends ByteToMessageDecoderForBuffer {
+public class Socks5CommandRequestDecoder extends ByteToMessageDecoder {
 
     private enum State {
         INIT,

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5CommandResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5CommandResponseDecoder.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.codec.socksx.v5;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
+import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;
 import io.netty5.handler.codec.DecoderResult;
 import io.netty.contrib.handler.codec.socksx.SocksVersion;
@@ -30,7 +30,7 @@ import static java.util.Objects.requireNonNull;
  * other handler can remove or replace this decoder later.  On failed decode, this decoder will
  * discard the received data, so that other handler closes the connection later.
  */
-public class Socks5CommandResponseDecoder extends ByteToMessageDecoderForBuffer {
+public class Socks5CommandResponseDecoder extends ByteToMessageDecoder {
 
     private enum State {
         INIT,

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5InitialRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5InitialRequestDecoder.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.codec.socksx.v5;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
+import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;
 import io.netty5.handler.codec.DecoderResult;
 import io.netty.contrib.handler.codec.socksx.SocksVersion;
@@ -28,7 +28,7 @@ import io.netty.contrib.handler.codec.socksx.SocksVersion;
  * other handler can remove or replace this decoder later.  On failed decode, this decoder will
  * discard the received data, so that other handler closes the connection later.
  */
-public class Socks5InitialRequestDecoder extends ByteToMessageDecoderForBuffer {
+public class Socks5InitialRequestDecoder extends ByteToMessageDecoder {
 
     private enum State {
         INIT,

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5InitialResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5InitialResponseDecoder.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.codec.socksx.v5;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
+import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;
 import io.netty5.handler.codec.DecoderResult;
 import io.netty.contrib.handler.codec.socksx.SocksVersion;
@@ -28,7 +28,7 @@ import io.netty.contrib.handler.codec.socksx.SocksVersion;
  * other handler can remove or replace this decoder later.  On failed decode, this decoder will
  * discard the received data, so that other handler closes the connection later.
  */
-public class Socks5InitialResponseDecoder extends ByteToMessageDecoderForBuffer {
+public class Socks5InitialResponseDecoder extends ByteToMessageDecoder {
 
     private enum State {
         INIT,

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5PasswordAuthRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5PasswordAuthRequestDecoder.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.codec.socksx.v5;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
+import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;
 import io.netty5.handler.codec.DecoderResult;
 import io.netty5.util.CharsetUtil;
@@ -28,7 +28,7 @@ import io.netty5.util.CharsetUtil;
  * other handler can remove or replace this decoder later.  On failed decode, this decoder will
  * discard the received data, so that other handler closes the connection later.
  */
-public class Socks5PasswordAuthRequestDecoder extends ByteToMessageDecoderForBuffer {
+public class Socks5PasswordAuthRequestDecoder extends ByteToMessageDecoder {
 
     private enum State {
         INIT,

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5PasswordAuthResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5PasswordAuthResponseDecoder.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.codec.socksx.v5;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
+import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;
 import io.netty5.handler.codec.DecoderResult;
 
@@ -27,7 +27,7 @@ import io.netty5.handler.codec.DecoderResult;
  * other handler can remove or replace this decoder later.  On failed decode, this decoder will
  * discard the received data, so that other handler closes the connection later.
  */
-public class Socks5PasswordAuthResponseDecoder extends ByteToMessageDecoderForBuffer {
+public class Socks5PasswordAuthResponseDecoder extends ByteToMessageDecoder {
 
     private enum State {
         INIT,

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5ServerEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5ServerEncoder.java
@@ -19,7 +19,7 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.EncoderException;
-import io.netty5.handler.codec.MessageToByteEncoderForBuffer;
+import io.netty5.handler.codec.MessageToByteEncoder;
 import io.netty5.util.internal.StringUtil;
 
 import static java.util.Objects.requireNonNull;
@@ -28,7 +28,7 @@ import static java.util.Objects.requireNonNull;
  * Encodes a server-side {@link Socks5Message} into a {@link Buffer}.
  */
 @Sharable
-public class Socks5ServerEncoder extends MessageToByteEncoderForBuffer<Socks5Message> {
+public class Socks5ServerEncoder extends MessageToByteEncoder<Socks5Message> {
 
     public static final Socks5ServerEncoder DEFAULT = new Socks5ServerEncoder(Socks5AddressEncoder.DEFAULT);
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5ServerEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5ServerEncoder.java
@@ -16,7 +16,6 @@
 package io.netty.contrib.handler.codec.socksx.v5;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.EncoderException;
 import io.netty5.handler.codec.MessageToByteEncoder;
@@ -27,7 +26,6 @@ import static java.util.Objects.requireNonNull;
 /**
  * Encodes a server-side {@link Socks5Message} into a {@link Buffer}.
  */
-@Sharable
 public class Socks5ServerEncoder extends MessageToByteEncoder<Socks5Message> {
 
     public static final Socks5ServerEncoder DEFAULT = new Socks5ServerEncoder(Socks5AddressEncoder.DEFAULT);
@@ -95,5 +93,10 @@ public class Socks5ServerEncoder extends MessageToByteEncoder<Socks5Message> {
         addressEncoder.encodeAddress(bndAddrType, msg.bndAddr(), out);
 
         out.writeShort((short) msg.bndPort());
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 }

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/SocksServerConnectHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/SocksServerConnectHandler.java
@@ -17,7 +17,6 @@ package io.netty.contrib.handler.codec.example.socksproxy;
 
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.channel.Channel;
-import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.SimpleChannelInboundHandler;
@@ -32,7 +31,6 @@ import io.netty.contrib.handler.codec.socksx.v5.Socks5CommandStatus;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
 
-@ChannelHandler.Sharable
 public final class SocksServerConnectHandler extends SimpleChannelInboundHandler<SocksMessage> {
 
     private final Bootstrap b = new Bootstrap();
@@ -128,5 +126,10 @@ public final class SocksServerConnectHandler extends SimpleChannelInboundHandler
     @Override
     public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         SocksServerUtils.closeOnFlush(ctx.channel());
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 }

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/SocksServerHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/SocksServerHandler.java
@@ -15,7 +15,6 @@
  */
 package io.netty.contrib.handler.codec.example.socksproxy;
 
-import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.SimpleChannelInboundHandler;
 import io.netty.contrib.handler.codec.socksx.SocksMessage;
@@ -31,7 +30,6 @@ import io.netty.contrib.handler.codec.socksx.v5.Socks5InitialRequest;
 import io.netty.contrib.handler.codec.socksx.v5.Socks5PasswordAuthRequest;
 import io.netty.contrib.handler.codec.socksx.v5.Socks5PasswordAuthStatus;
 
-@ChannelHandler.Sharable
 public final class SocksServerHandler extends SimpleChannelInboundHandler<SocksMessage> {
 
     public static final SocksServerHandler INSTANCE = new SocksServerHandler();
@@ -89,5 +87,10 @@ public final class SocksServerHandler extends SimpleChannelInboundHandler<SocksM
     public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable throwable) {
         throwable.printStackTrace();
         SocksServerUtils.closeOnFlush(ctx.channel());
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 }

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/UnresponsiveHandler.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/UnresponsiveHandler.java
@@ -15,11 +15,9 @@
  */
 package io.netty.contrib.handler.proxy;
 
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.SimpleChannelInboundHandler;
 
-@Sharable
 final class UnresponsiveHandler extends SimpleChannelInboundHandler<Object> {
 
     static final UnresponsiveHandler INSTANCE = new UnresponsiveHandler();
@@ -29,5 +27,10 @@ final class UnresponsiveHandler extends SimpleChannelInboundHandler<Object> {
     @Override
     protected void messageReceived(ChannelHandlerContext ctx, Object msg) throws Exception {
         // Ignore
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 }


### PR DESCRIPTION
Motivation:

With https://github.com/netty/netty/pull/12512
`ByteToMessageDecoderForBuffer` is renamed to `ByteToMessageDecoder`, and
`MessageToByteEncoderForBuffer` is renamed to `MessageToByteEncoder`.
The code needs adaptation.

Modifications:

- All decoders now extend `ByteToMessageDecoder`
- All encoders now extend `MessageToByteEncoder`

Result:

The code is adapted to the new changes in the API.