### PR TITLE
Adapt to changes made in Future interface

### DIFF
--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/SocksServer.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/SocksServer.java
@@ -36,7 +36,7 @@ public final class SocksServer {
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new SocksServerInitializer());
-            b.bind(PORT).get().closeFuture().sync();
+            b.bind(PORT).asStage().get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/HttpProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/HttpProxyHandlerTest.java
@@ -209,7 +209,7 @@ public class HttpProxyHandlerTest {
                             });
                         }
                     }).bind(addr);
-            serverChannel = sf.get();
+            serverChannel = sf.asStage().get();
             Future<Channel> cf = new Bootstrap().channel(LocalChannel.class).group(group).handler(
                 new ChannelInitializer<Channel>() {
                     @Override
@@ -224,7 +224,7 @@ public class HttpProxyHandlerTest {
                         });
                     }
                 }).connect(new InetSocketAddress("localhost", 1234));
-            clientChannel = cf.get();
+            clientChannel = cf.asStage().get();
             clientChannel.close().sync();
 
             assertTrue(exception.get() instanceof HttpProxyConnectException);

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyHandlerTest.java
@@ -658,7 +658,7 @@ public class ProxyHandlerTest {
                 }
             });
 
-            Channel channel = b.connect(destination).get();
+            Channel channel = b.connect(destination).asStage().get();
             boolean finished = channel.closeFuture().await(10, TimeUnit.SECONDS);
 
             logger.debug("Received messages: {}", testHandler.received);
@@ -707,7 +707,7 @@ public class ProxyHandlerTest {
                 }
             });
 
-            Channel channel = b.connect(destination).get();
+            Channel channel = b.connect(destination).asStage().get();
             boolean finished = channel.closeFuture().await(10, TimeUnit.SECONDS);
             finished &= testHandler.latch.await(10, TimeUnit.SECONDS);
 
@@ -753,7 +753,7 @@ public class ProxyHandlerTest {
                 }
             });
 
-            Channel channel = b.connect(DESTINATION).get();
+            Channel channel = b.connect(DESTINATION).asStage().get();
             Future<Void> cf = channel.closeFuture();
             boolean finished = cf.await(TIMEOUT * 2, TimeUnit.MILLISECONDS);
             finished &= testHandler.latch.await(TIMEOUT * 2, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Motivation:

blocking JDK Future methods have moved to FutureCompletableStage interface: see https://github.com/netty/netty/pull/12548
The code needs to be adapted.

Modifications:

Changed _Future.get()_ to _Future.asStage().get()_

Result:

The code is adapted to the new changes in the API.