### PR TITLE
Adapt to changes made in Future interface

### DIFF
--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/SocksServer.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/socksproxy/SocksServer.java
@@ -36,7 +36,7 @@ public final class SocksServer {
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new SocksServerInitializer());
-            b.bind(PORT).asStage().get().closeFuture().sync();
+            b.bind(PORT).asStage().get().closeFuture().asStage().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/HttpProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/HttpProxyHandlerTest.java
@@ -225,7 +225,7 @@ public class HttpProxyHandlerTest {
                     }
                 }).connect(new InetSocketAddress("localhost", 1234));
             clientChannel = cf.asStage().get();
-            clientChannel.close().sync();
+            clientChannel.close().asStage().sync();
 
             assertTrue(exception.get() instanceof HttpProxyConnectException);
             HttpProxyConnectException actual = (HttpProxyConnectException) exception.get();

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyHandlerTest.java
@@ -659,7 +659,7 @@ public class ProxyHandlerTest {
             });
 
             Channel channel = b.connect(destination).asStage().get();
-            boolean finished = channel.closeFuture().await(10, TimeUnit.SECONDS);
+            boolean finished = channel.closeFuture().asStage().await(10, TimeUnit.SECONDS);
 
             logger.debug("Received messages: {}", testHandler.received);
 
@@ -708,7 +708,7 @@ public class ProxyHandlerTest {
             });
 
             Channel channel = b.connect(destination).asStage().get();
-            boolean finished = channel.closeFuture().await(10, TimeUnit.SECONDS);
+            boolean finished = channel.closeFuture().asStage().await(10, TimeUnit.SECONDS);
             finished &= testHandler.latch.await(10, TimeUnit.SECONDS);
 
             logger.debug("Recorded exceptions: {}", testHandler.exceptions);
@@ -755,7 +755,7 @@ public class ProxyHandlerTest {
 
             Channel channel = b.connect(DESTINATION).asStage().get();
             Future<Void> cf = channel.closeFuture();
-            boolean finished = cf.await(TIMEOUT * 2, TimeUnit.MILLISECONDS);
+            boolean finished = cf.asStage().await(TIMEOUT * 2, TimeUnit.MILLISECONDS);
             finished &= testHandler.latch.await(TIMEOUT * 2, TimeUnit.MILLISECONDS);
 
             logger.debug("Recorded exceptions: {}", testHandler.exceptions);

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyServer.java
@@ -106,7 +106,7 @@ abstract class ProxyServer {
             }
         });
 
-        ch = (ServerSocketChannel) b.bind(NetUtil.LOCALHOST, 0).sync().getNow();
+        ch = (ServerSocketChannel) b.bind(NetUtil.LOCALHOST, 0).asStage().sync().getNow();
     }
 
     public final InetSocketAddress address() {


### PR DESCRIPTION
Motivation:

The `await()` (with and without timeout) and `sync()` methods have been removed
from the `Future` interface and added to the `FutureCompletionStage` interface.
https://github.com/netty/netty/pull/12569
The code needs to be adapted.

Modifications:

- Changed `Future.sync()` to `Future.asStage().sync()`
- Changed `Future.await(...)` to `Future.asStage().await(...)`

Result:

The code is adapted to the new changes in the API.