### PR TITLE
Change Netty Core version to non-snapshot Alpha3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
   </developers>
 
   <properties>
-    <netty.version>5.0.0.Alpha3-SNAPSHOT</netty.version>
+    <netty.version>5.0.0.Alpha3</netty.version>
     <netty.build.version>29</netty.build.version>
     <project.scm.id>github</project.scm.id>
     <release.gpg.keyname />


### PR DESCRIPTION
Motivation:
With Netty 5 Alpha 3 we have reached a point where we can start to track the released alphas instead of the latest snapshot.

Modification:
Change the Netty Core dependency to be a non-snapshot version of Netty 5 Alpha 3.

Result:
We're now tracking released versions of Netty 5.