### PR TITLE
Fix project's SNAPSHOT version

### DIFF
--- a/codec-socks/pom.xml
+++ b/codec-socks/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>io.netty.contrib</groupId>
         <artifactId>netty-socks-proxy-parent</artifactId>
-        <version>5.0.1.Alpha1-SNAPSHOT</version>
+        <version>5.0.0.Alpha2-SNAPSHOT</version>
     </parent>
 
     <artifactId>netty-codec-socks</artifactId>
-    <version>5.0.1.Alpha1-SNAPSHOT</version>
+    <version>5.0.0.Alpha2-SNAPSHOT</version>
     <name>Netty/Codec/Socks</name>
     <packaging>jar</packaging>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>io.netty.contrib</groupId>
         <artifactId>netty-socks-proxy-parent</artifactId>
-        <version>5.0.1.Alpha1-SNAPSHOT</version>
+        <version>5.0.0.Alpha2-SNAPSHOT</version>
     </parent>
 
     <artifactId>netty-socks-proxy-examples</artifactId>
-    <version>5.0.1.Alpha1-SNAPSHOT</version>
+    <version>5.0.0.Alpha2-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/handler-proxy/pom.xml
+++ b/handler-proxy/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>io.netty.contrib</groupId>
         <artifactId>netty-socks-proxy-parent</artifactId>
-        <version>5.0.1.Alpha1-SNAPSHOT</version>
+        <version>5.0.0.Alpha2-SNAPSHOT</version>
     </parent>
 
     <artifactId>netty-handler-proxy</artifactId>
-    <version>5.0.1.Alpha1-SNAPSHOT</version>
+    <version>5.0.0.Alpha2-SNAPSHOT</version>
 
     <build>
         <extensions>


### PR DESCRIPTION
Motivation:

The pom files specify a wrong SNAPSHOT version -
`5.0.1.Alpha1-SNAPSHOT` instead of `5.0.0.Alpha2-SNAPSHOT`

Modifications:

Fix project's SNAPSHOT version.

Result:

Project can be built successfully.