### PR TITLE
Adapt to Netty 5.0.0.Alpha5-SNAPSHOT changes

### DIFF
--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/AbstractSocksMessage.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/AbstractSocksMessage.java
@@ -24,7 +24,7 @@ import static java.util.Objects.requireNonNull;
  */
 public abstract class AbstractSocksMessage implements SocksMessage {
 
-    private DecoderResult decoderResult = DecoderResult.SUCCESS;
+    private DecoderResult decoderResult = DecoderResult.success();
 
     @Override
     public DecoderResult decoderResult() {

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socksx/v5/Socks5InitialRequestDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socksx/v5/Socks5InitialRequestDecoderTest.java
@@ -33,7 +33,7 @@ public class Socks5InitialRequestDecoderTest {
 
         assertTrue(o instanceof DefaultSocks5InitialRequest);
         DefaultSocks5InitialRequest req = (DefaultSocks5InitialRequest) o;
-        assertSame(req.decoderResult(), DecoderResult.SUCCESS);
+        assertSame(req.decoderResult(), DecoderResult.success());
         assertFalse(e.finish());
     }
 }

--- a/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/ProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/ProxyHandler.java
@@ -18,6 +18,7 @@ package io.netty.contrib.handler.proxy;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.channel.ChannelOption;
 import io.netty5.channel.PendingWriteQueue;
 import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.DefaultPromise;
@@ -409,7 +410,7 @@ public abstract class ProxyHandler implements ChannelHandler {
     }
 
     private static void readIfNeeded(ChannelHandlerContext ctx) {
-        if (!ctx.channel().config().isAutoRead()) {
+        if (!ctx.channel().getOption(ChannelOption.AUTO_READ)) {
             ctx.read();
         }
     }
@@ -433,7 +434,7 @@ public abstract class ProxyHandler implements ChannelHandler {
         PendingWriteQueue pendingWrites = this.pendingWrites;
         if (pendingWrites == null) {
             this.pendingWrites = pendingWrites = new PendingWriteQueue(ctx.executor(),
-                    ctx.channel().config().getMessageSizeEstimator().newHandle());
+                    ctx.channel().getOption(ChannelOption.MESSAGE_SIZE_ESTIMATOR).newHandle());
         }
         pendingWrites.add(msg, promise);
     }

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyHandlerTest.java
@@ -472,7 +472,7 @@ public class ProxyHandlerTest {
         volatile int eventCount;
 
         private static void readIfNeeded(ChannelHandlerContext ctx) {
-            if (!ctx.channel().config().isAutoRead()) {
+            if (!ctx.channel().getOption(ChannelOption.AUTO_READ)) {
                 ctx.read();
             }
         }

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyServer.java
@@ -110,7 +110,7 @@ abstract class ProxyServer {
     }
 
     public final InetSocketAddress address() {
-        return new InetSocketAddress(NetUtil.LOCALHOST, ch.localAddress().getPort());
+        return new InetSocketAddress(NetUtil.LOCALHOST, ((InetSocketAddress) ch.localAddress()).getPort());
     }
 
     protected abstract void configure(SocketChannel ch) throws Exception;

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
   </developers>
 
   <properties>
-    <netty.version>5.0.0.Alpha3</netty.version>
+    <netty.version>5.0.0.Alpha5-SNAPSHOT</netty.version>
     <netty.build.version>29</netty.build.version>
     <project.scm.id>github</project.scm.id>
     <release.gpg.keyname />


### PR DESCRIPTION
Motivation:

The build of the project is broken. This change is adapting the code to the changes in Netty `5.0.0.Alpha5-SNAPSHOT`.

Modifications:

- Adapt to the new way of setting channel options
- `io.netty5.channel.Channel#localAddress` now returns `SocketAddress`
- Adapt to the changes in the API for obtaining `Decoder` results

Result:

The build of the project is green again