### PR TITLE
Add reflection hints for better native-image support

### DIFF
--- a/codec-socks/src/main/resources/META-INF/native-image/io.netty.contrib/netty-codec-socks/reflect-config.json
+++ b/codec-socks/src/main/resources/META-INF/native-image/io.netty.contrib/netty-codec-socks/reflect-config.json
@@ -1,0 +1,82 @@
+[
+  {
+    "name": "io.netty.contrib.handler.codec.socks.SocksAuthRequestDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.codec.socks.SocksAuthResponseDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.codec.socks.SocksCmdRequestDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.codec.socks.SocksCmdResponseDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.codec.socks.SocksInitRequestDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.codec.socks.SocksInitResponseDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.codec.socks.SocksMessageEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.codec.socksx.SocksPortUnificationServerHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.codec.socksx.v4.Socks4ClientDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.codec.socksx.v4.Socks4ClientEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.codec.socksx.v4.Socks4ServerDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.codec.socksx.v4.Socks4ServerEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.codec.socksx.v5.Socks5ClientEncoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.codec.socksx.v5.Socks5CommandRequestDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.codec.socksx.v5.Socks5CommandResponseDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.codec.socksx.v5.Socks5InitialRequestDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.codec.socksx.v5.Socks5InitialResponseDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.codec.socksx.v5.Socks5PasswordAuthRequestDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.codec.socksx.v5.Socks5PasswordAuthResponseDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.codec.socksx.v5.Socks5ServerEncoder",
+    "queryAllPublicMethods": true
+  }
+]

--- a/handler-proxy/src/main/resources/META-INF/native-image/io.netty.contrib/netty-handler-proxy/reflect-config.json
+++ b/handler-proxy/src/main/resources/META-INF/native-image/io.netty.contrib/netty-handler-proxy/reflect-config.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "io.netty.contrib.handler.proxy.HttpProxyHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.proxy.HttpProxyHandler$HttpClientCodecWrapper",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.proxy.ProxyHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.proxy.Socks4ProxyHandler",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.proxy.Socks5ProxyHandler",
+    "queryAllPublicMethods": true
+  }
+]


### PR DESCRIPTION
Motivation:

When a `ChannelHandler` is added to the `Netty` channel pipeline,
`io.netty5.channel.ChannelHandlerMask#mask0` will inspect the `ChannelHandler's` methods for
`io.netty5.channel.ChannelHandlerMask.Skip` annotation.
When there are no reflection hints, `NoSuchMethodException` is thrown when trying to query the methods.
This will lead to methods marked as not skippable, although the program will be able to run
without any problems, when all methods are marked as not skippable, one might observe performance issues.

Modifications:

- Add `reflect-config.json` with configuration for various channel handlers
There is no need to add conditional configuration as this is just for querying methods, the impact on footprint should be low.

Result:

Better native-image support