### PR TITLE
Adapt to netty changes for CharsetUtil

### DIFF
--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthRequest.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthRequest.java
@@ -18,6 +18,7 @@ package io.netty.contrib.handler.codec.socks;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.util.CharsetUtil;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.charset.CharsetEncoder;
 
 import static java.util.Objects.requireNonNull;
@@ -38,7 +39,7 @@ public final class SocksAuthRequest extends SocksRequest {
         requireNonNull(username, "username");
         requireNonNull(password, "password");
 
-        final CharsetEncoder asciiEncoder = CharsetUtil.encoder(CharsetUtil.US_ASCII);
+        final CharsetEncoder asciiEncoder = CharsetUtil.encoder(StandardCharsets.US_ASCII);
         if (!asciiEncoder.canEncode(username) || !asciiEncoder.canEncode(password)) {
             throw new IllegalArgumentException(
                     "username: " + username + " or password: **** values should be in pure ascii");
@@ -75,8 +76,8 @@ public final class SocksAuthRequest extends SocksRequest {
     public void encodeAsBuffer(Buffer buffer) {
         buffer.writeByte(SUBNEGOTIATION_VERSION.byteValue());
         buffer.writeByte((byte) username.length());
-        buffer.writeCharSequence(username, CharsetUtil.US_ASCII);
+        buffer.writeCharSequence(username, StandardCharsets.US_ASCII);
         buffer.writeByte((byte) password.length());
-        buffer.writeCharSequence(password, CharsetUtil.US_ASCII);
+        buffer.writeCharSequence(password, StandardCharsets.US_ASCII);
     }
 }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthRequestDecoder.java
@@ -18,7 +18,7 @@ package io.netty.contrib.handler.codec.socks;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Decodes {@link Buffer}s into {@link SocksAuthRequest}.
@@ -56,7 +56,7 @@ public class SocksAuthRequestDecoder extends ByteToMessageDecoder {
                     return;
                 }
                 buffer.skipReadableBytes(1);
-                username = buffer.readCharSequence(fieldLength, CharsetUtil.US_ASCII).toString();
+                username = buffer.readCharSequence(fieldLength, StandardCharsets.US_ASCII).toString();
                 state = State.READ_PASSWORD;
             }
             case READ_PASSWORD: {
@@ -68,7 +68,7 @@ public class SocksAuthRequestDecoder extends ByteToMessageDecoder {
                     return;
                 }
                 buffer.skipReadableBytes(1);
-                String password = buffer.readCharSequence(fieldLength, CharsetUtil.US_ASCII).toString();
+                String password = buffer.readCharSequence(fieldLength, StandardCharsets.US_ASCII).toString();
                 ctx.fireChannelRead(new SocksAuthRequest(username, password));
                 break;
             }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdRequest.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdRequest.java
@@ -16,7 +16,7 @@
 package io.netty.contrib.handler.codec.socks;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import io.netty5.util.NetUtil;
 
 import java.net.IDN;
@@ -122,7 +122,7 @@ public final class SocksCmdRequest extends SocksRequest {
 
             case DOMAIN: {
                 buffer.writeByte((byte) host.length());
-                buffer.writeCharSequence(host, CharsetUtil.US_ASCII);
+                buffer.writeCharSequence(host, StandardCharsets.US_ASCII);
                 buffer.writeShort((short) port);
                 break;
             }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdRequestDecoder.java
@@ -18,7 +18,7 @@ package io.netty.contrib.handler.codec.socks;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import io.netty5.util.NetUtil;
 
 /**
@@ -79,7 +79,7 @@ public class SocksCmdRequestDecoder extends ByteToMessageDecoder {
                             return;
                         }
                         buffer.skipReadableBytes(1);
-                        String host = buffer.readCharSequence(fieldLength, CharsetUtil.US_ASCII).toString();
+                        String host = buffer.readCharSequence(fieldLength, StandardCharsets.US_ASCII).toString();
                         int port = buffer.readUnsignedShort();
                         ctx.fireChannelRead(new SocksCmdRequest(cmdType, addressType, host, port));
                         break;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdResponse.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdResponse.java
@@ -16,7 +16,7 @@
 package io.netty.contrib.handler.codec.socks;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import io.netty5.util.NetUtil;
 
 import java.net.IDN;
@@ -154,7 +154,7 @@ public final class SocksCmdResponse extends SocksResponse {
             case DOMAIN: {
                 if (host != null) {
                     buffer.writeByte((byte) host.length());
-                    buffer.writeCharSequence(host, CharsetUtil.US_ASCII);
+                    buffer.writeCharSequence(host, StandardCharsets.US_ASCII);
                 } else {
                     buffer.writeByte((byte) DOMAIN_ZEROED.length);
                     buffer.writeBytes(DOMAIN_ZEROED);

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdResponseDecoder.java
@@ -18,7 +18,7 @@ package io.netty.contrib.handler.codec.socks;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import io.netty5.util.NetUtil;
 
 /**
@@ -78,7 +78,7 @@ public class SocksCmdResponseDecoder extends ByteToMessageDecoder {
                             return;
                         }
                         buffer.skipReadableBytes(1);
-                        String host = buffer.readCharSequence(fieldLength, CharsetUtil.US_ASCII).toString();
+                        String host = buffer.readCharSequence(fieldLength, StandardCharsets.US_ASCII).toString();
                         int port = buffer.readUnsignedShort();
                         ctx.fireChannelRead(new SocksCmdResponse(cmdStatus, addressType, host, port));
                         break;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ClientEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ClientEncoder.java
@@ -18,7 +18,7 @@ package io.netty.contrib.handler.codec.socksx.v4;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import io.netty5.util.NetUtil;
 
 /**
@@ -47,13 +47,13 @@ public final class Socks4ClientEncoder extends MessageToByteEncoder<Socks4Comman
         out.writeShort((short) msg.dstPort());
         if (NetUtil.isValidIpV4Address(msg.dstAddr())) {
             out.writeBytes(NetUtil.createByteArrayFromIpAddressString(msg.dstAddr()));
-            out.writeCharSequence(msg.userId(), CharsetUtil.US_ASCII);
+            out.writeCharSequence(msg.userId(), StandardCharsets.US_ASCII);
             out.writeByte((byte) 0);
         } else {
             out.writeBytes(IPv4_DOMAIN_MARKER);
-            out.writeCharSequence(msg.userId(), CharsetUtil.US_ASCII);
+            out.writeCharSequence(msg.userId(), StandardCharsets.US_ASCII);
             out.writeByte((byte) 0);
-            out.writeCharSequence(msg.dstAddr(), CharsetUtil.US_ASCII);
+            out.writeCharSequence(msg.dstAddr(), StandardCharsets.US_ASCII);
             out.writeByte((byte) 0);
         }
     }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ServerDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ServerDecoder.java
@@ -21,7 +21,7 @@ import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;
 import io.netty5.handler.codec.DecoderResult;
 import io.netty.contrib.handler.codec.socksx.SocksVersion;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import io.netty5.util.NetUtil;
 
 /**
@@ -133,7 +133,7 @@ public class Socks4ServerDecoder extends ByteToMessageDecoder {
             if (in.readableBytes() < length + 1) {
                 return null;
             }
-            String value = in.readCharSequence(length, CharsetUtil.US_ASCII).toString();
+            String value = in.readCharSequence(length, StandardCharsets.US_ASCII).toString();
             in.skipReadableBytes(1); // Skip the NUL.
 
             return value;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5AddressDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5AddressDecoder.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.codec.socksx.v5;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.handler.codec.DecoderException;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import io.netty5.util.NetUtil;
 
 /**
@@ -50,7 +50,7 @@ public interface Socks5AddressDecoder {
                     return null;
                 }
                 in.skipReadableBytes(1);
-                return in.readCharSequence(length, CharsetUtil.US_ASCII).toString();
+                return in.readCharSequence(length, StandardCharsets.US_ASCII).toString();
             }
             if (addrType == Socks5AddressType.IPv6) {
                 if (readableBytes < IPv6_LEN) {

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5AddressEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5AddressEncoder.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.codec.socksx.v5;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.handler.codec.EncoderException;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import io.netty5.util.NetUtil;
 
 /**
@@ -39,7 +39,7 @@ public interface Socks5AddressEncoder {
         } else if (typeVal == Socks5AddressType.DOMAIN.byteValue()) {
             if (addrValue != null) {
                 out.writeByte((byte) addrValue.length());
-                out.writeCharSequence(addrValue, CharsetUtil.US_ASCII);
+                out.writeCharSequence(addrValue, StandardCharsets.US_ASCII);
             } else {
                 out.writeByte((byte) 0);
             }

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5ClientEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5ClientEncoder.java
@@ -19,7 +19,7 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.EncoderException;
 import io.netty5.handler.codec.MessageToByteEncoder;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import io.netty5.util.internal.StringUtil;
 
 import java.util.List;
@@ -100,11 +100,11 @@ public class Socks5ClientEncoder extends MessageToByteEncoder<Socks5Message> {
 
         final String username = msg.username();
         out.writeByte((byte) username.length());
-        out.writeCharSequence(username, CharsetUtil.US_ASCII);
+        out.writeCharSequence(username, StandardCharsets.US_ASCII);
 
         final String password = msg.password();
         out.writeByte((byte) password.length());
-        out.writeCharSequence(password, CharsetUtil.US_ASCII);
+        out.writeCharSequence(password, StandardCharsets.US_ASCII);
     }
 
     private void encodeCommandRequest(Socks5CommandRequest msg, Buffer out) throws Exception {

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5PasswordAuthRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5PasswordAuthRequestDecoder.java
@@ -20,7 +20,7 @@ import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;
 import io.netty5.handler.codec.DecoderResult;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Decodes a single {@link Socks5PasswordAuthRequest} from the inbound {@link Buffer}s.
@@ -59,9 +59,9 @@ public class Socks5PasswordAuthRequestDecoder extends ByteToMessageDecoder {
                     return;
                 }
                 in.skipReadableBytes(2);
-                String username = in.readCharSequence(usernameLength, CharsetUtil.US_ASCII).toString();
+                String username = in.readCharSequence(usernameLength, StandardCharsets.US_ASCII).toString();
                 in.skipReadableBytes(1);
-                String password = in.readCharSequence(passwordLength, CharsetUtil.US_ASCII).toString();
+                String password = in.readCharSequence(passwordLength, StandardCharsets.US_ASCII).toString();
                 ctx.fireChannelRead(new DefaultSocks5PasswordAuthRequest(username, password));
 
                 state = State.SUCCESS;

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCmdRequestTest.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCmdRequestTest.java
@@ -16,7 +16,7 @@
 package io.netty.contrib.handler.codec.socks;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 import java.net.IDN;
@@ -107,7 +107,7 @@ public class SocksCmdRequestTest {
             assertEquals(SocksAddressType.DOMAIN.byteValue(), buffer.readByte());
             assertEquals((byte) asciiHost.length(), buffer.readUnsignedByte());
             assertEquals(asciiHost,
-                    CharBuffer.wrap(buffer.readCharSequence(asciiHost.length(), CharsetUtil.US_ASCII)));
+                    CharBuffer.wrap(buffer.readCharSequence(asciiHost.length(), StandardCharsets.US_ASCII)));
             assertEquals(port, buffer.readUnsignedShort());
         }
     }

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCmdResponseTest.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCmdResponseTest.java
@@ -16,7 +16,7 @@
 package io.netty.contrib.handler.codec.socks;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 import java.net.IDN;
@@ -151,7 +151,7 @@ public class SocksCmdResponseTest {
             assertEquals(SocksAddressType.DOMAIN.byteValue(), buffer.readByte());
             assertEquals((byte) asciiHost.length(), buffer.readUnsignedByte());
             assertEquals(asciiHost,
-                    CharBuffer.wrap(buffer.readCharSequence(asciiHost.length(), CharsetUtil.US_ASCII)));
+                    CharBuffer.wrap(buffer.readCharSequence(asciiHost.length(), StandardCharsets.US_ASCII)));
             assertEquals(port, buffer.readUnsignedShort());
         }
     }

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyHandlerTest.java
@@ -35,7 +35,7 @@ import io.netty5.handler.ssl.SslContextBuilder;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import io.netty5.resolver.NoopAddressResolverGroup;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import io.netty5.util.concurrent.DefaultThreadFactory;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.internal.SocketUtils;
@@ -499,7 +499,7 @@ public class ProxyHandlerTest {
 
         @Override
         protected void messageReceived(ChannelHandlerContext ctx, Object msg) {
-            String str = ((Buffer) msg).toString(CharsetUtil.US_ASCII);
+            String str = ((Buffer) msg).toString(StandardCharsets.US_ASCII);
             received.add(str);
             if ("2".equals(str)) {
                 ctx.writeAndFlush(writeAscii(ctx.bufferAllocator(), "C\n"));

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyServer.java
@@ -30,7 +30,7 @@ import io.netty5.channel.socket.ServerSocketChannel;
 import io.netty5.channel.socket.SocketChannel;
 import io.netty5.channel.socket.nio.NioServerSocketChannel;
 import io.netty5.channel.socket.nio.NioSocketChannel;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import io.netty5.util.NetUtil;
 import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.Future;
@@ -267,7 +267,7 @@ abstract class ProxyServer {
         @Override
         protected final void messageReceived(ChannelHandlerContext ctx, Object msg) throws Exception {
             if (finished) {
-                String str = ((Buffer) msg).toString(CharsetUtil.US_ASCII);
+                String str = ((Buffer) msg).toString(StandardCharsets.US_ASCII);
                 if ("A\n".equals(str)) {
                     ctx.write(writeAscii(ctx.bufferAllocator(), "1\n"));
                 } else if ("B\n".equals(str)) {

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/Socks5ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/Socks5ProxyServer.java
@@ -35,7 +35,7 @@ import io.netty.contrib.handler.codec.socksx.v5.Socks5PasswordAuthRequestDecoder
 import io.netty.contrib.handler.codec.socksx.v5.Socks5PasswordAuthStatus;
 import io.netty.contrib.handler.codec.socksx.v5.Socks5ServerEncoder;
 import io.netty5.handler.codec.LineBasedFrameDecoder;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import io.netty5.util.internal.SocketUtils;
 
 import java.net.InetSocketAddress;


### PR DESCRIPTION
**Motivation:**

The socks-proxy module needs to be adapted to the following netty PR:

Remove Charset constants from CharsetUtil (https://github.com/netty/netty/pull/12741)

**Modification:**

Netty CharsetUtil constants need to be replaced by the ones from java.nio.charset.StandardCharsets

**Result:**

The socks-proxy module can be built again, and this will unblock the reactor-netty build based on netty5