### PR TITLE
Adapt to new HttpHeaders API

### DIFF
--- a/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/HttpProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/HttpProxyHandler.java
@@ -24,7 +24,7 @@ import io.netty5.handler.codec.http.DefaultFullHttpRequest;
 import io.netty5.handler.codec.http.FullHttpRequest;
 import io.netty5.handler.codec.http.HttpClientCodec;
 import io.netty5.handler.codec.http.HttpHeaderNames;
-import io.netty5.handler.codec.http.HttpHeaders;
+import io.netty5.handler.codec.http.headers.HttpHeaders;
 import io.netty5.handler.codec.http.HttpMethod;
 import io.netty5.handler.codec.http.HttpResponse;
 import io.netty5.handler.codec.http.HttpResponseStatus;

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/HttpProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/HttpProxyHandlerTest.java
@@ -31,13 +31,12 @@ import io.netty5.channel.local.LocalHandler;
 import io.netty5.channel.local.LocalServerChannel;
 import io.netty.contrib.handler.proxy.HttpProxyHandler.HttpProxyConnectException;
 import io.netty5.handler.codec.http.DefaultFullHttpResponse;
-import io.netty5.handler.codec.http.DefaultHttpHeaders;
 import io.netty5.handler.codec.http.DefaultHttpResponse;
 import io.netty5.handler.codec.http.EmptyLastHttpContent;
 import io.netty5.handler.codec.http.FullHttpRequest;
 import io.netty5.handler.codec.http.HttpClientCodec;
 import io.netty5.handler.codec.http.HttpHeaderNames;
-import io.netty5.handler.codec.http.HttpHeaders;
+import io.netty5.handler.codec.http.headers.HttpHeaders;
 import io.netty5.handler.codec.http.HttpResponseEncoder;
 import io.netty5.handler.codec.http.HttpResponseStatus;
 import io.netty5.handler.codec.http.HttpVersion;
@@ -52,6 +51,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -177,7 +177,7 @@ public class HttpProxyHandlerTest {
                 socketAddress,
                 "10.0.0.1:8080",
                 "10.0.0.1:8080",
-                new DefaultHttpHeaders()
+                HttpHeaders.newHeaders()
                         .add("CUSTOM_HEADER", "CUSTOM_VALUE1")
                         .add("CUSTOM_HEADER", "CUSTOM_VALUE2"),
                 true);
@@ -276,8 +276,8 @@ public class HttpProxyHandlerTest {
 
             if (headers != null) {
                 // The actual request header is a strict superset of the custom header
-                for (String name : headers.names()) {
-                    assertEquals(headers.getAll(name), actualHeaders.getAll(name));
+                for (CharSequence name : headers.names()) {
+                    assertIterableEquals(headers.values(name), actualHeaders.values(name));
                 }
             }
         }

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/HttpProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/HttpProxyServer.java
@@ -24,6 +24,7 @@ import io.netty5.handler.codec.http.DefaultHttpContent;
 import io.netty5.handler.codec.http.FullHttpRequest;
 import io.netty5.handler.codec.http.FullHttpResponse;
 import io.netty5.handler.codec.http.HttpHeaderNames;
+import io.netty5.handler.codec.http.HttpHeaderValues;
 import io.netty5.handler.codec.http.HttpMethod;
 import io.netty5.handler.codec.http.HttpObjectAggregator;
 import io.netty5.handler.codec.http.HttpResponseStatus;
@@ -111,7 +112,7 @@ final class HttpProxyServer extends ProxyServer {
             if (!authenticate(ctx, req)) {
                 res = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.UNAUTHORIZED,
                         preferredAllocator().allocate(0));
-                res.headers().set(HttpHeaderNames.CONTENT_LENGTH, 0);
+                res.headers().set(HttpHeaderNames.CONTENT_LENGTH, HttpHeaderValues.ZERO);
             } else {
                 res = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
                         preferredAllocator().allocate(0));
@@ -144,11 +145,11 @@ final class HttpProxyServer extends ProxyServer {
             if (!authenticate(ctx, req)) {
                 res = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.UNAUTHORIZED,
                         preferredAllocator().allocate(0));
-                res.headers().set(HttpHeaderNames.CONTENT_LENGTH, 0);
+                res.headers().set(HttpHeaderNames.CONTENT_LENGTH, HttpHeaderValues.ZERO);
             } else if (!req.uri().equals(destination.getHostString() + ':' + destination.getPort())) {
                 res = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.FORBIDDEN,
                         preferredAllocator().allocate(0));
-                res.headers().set(HttpHeaderNames.CONTENT_LENGTH, 0);
+                res.headers().set(HttpHeaderNames.CONTENT_LENGTH, HttpHeaderValues.ZERO);
             } else {
                 res = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
                         preferredAllocator().allocate(0));


### PR DESCRIPTION
Motivation:

The socks-proxy project does not build anymore and we need to adapt it to the recent changes made in the netty5 PR https://github.com/netty/netty/pull/12735, with a new http headers API.

Motifications:

- use io.netty5.handler.codec.http.**headers**.HttpHeaders instead of io.netty5.handler.codec.http.HttpHeaders
- the HttpHeaders have to be instantiated using "HttpHeaders.newHeaders()"
- headers.getAll(name) has been replaced by headers.values(name)
- when setting a zero content length, "_headers().set(HttpHeaderNames.CONTENT_LENGTH, HttpHeaderValues.ZERO);_" is now used instead of "_headers().set(HttpHeaderNames.CONTENT_LENGTH, 0);_
- adapted the test in order to use assertIterableEquals instead of assertEquals

Result:

the socks-proxy project build is now fixed