### PR TITLE
Adapt to the changed package for Buffer API

### DIFF
--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthRequest.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthRequest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.util.CharsetUtil;
 
 import java.nio.charset.StandardCharsets;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthRequestDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import java.nio.charset.StandardCharsets;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthResponse.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthResponse.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 
 import static java.util.Objects.requireNonNull;
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksAuthResponseDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdRequest.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdRequest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import java.nio.charset.StandardCharsets;
 import io.netty5.util.NetUtil;
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdRequestDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import java.nio.charset.StandardCharsets;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdResponse.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdResponse.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import java.nio.charset.StandardCharsets;
 import io.netty5.util.NetUtil;
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksCmdResponseDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import java.nio.charset.StandardCharsets;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitRequest.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitRequest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 
 import java.util.Collections;
 import java.util.List;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitRequestDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitResponse.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitResponse.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 
 import static java.util.Objects.requireNonNull;
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksInitResponseDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksMessage.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksMessage.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 
 import static java.util.Objects.requireNonNull;
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksMessageEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/SocksMessageEncoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;
 

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/UnknownSocksRequest.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/UnknownSocksRequest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 
 /**
  * An unknown socks request.

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/UnknownSocksResponse.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socks/UnknownSocksResponse.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 
 /**
  * An unknown socks response.

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/SocksPortUnificationServerHandler.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/SocksPortUnificationServerHandler.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty.contrib.handler.codec.socksx.v4.Socks4ServerDecoder;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ClientDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ClientDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v4;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ClientEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ClientEncoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v4;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;
 import java.nio.charset.StandardCharsets;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ServerDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ServerDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v4;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ServerEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v4/Socks4ServerEncoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v4;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;
 import io.netty5.util.NetUtil;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5AddressDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5AddressDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.handler.codec.DecoderException;
 import java.nio.charset.StandardCharsets;
 import io.netty5.util.NetUtil;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5AddressEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5AddressEncoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.handler.codec.EncoderException;
 import java.nio.charset.StandardCharsets;
 import io.netty5.util.NetUtil;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5ClientEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5ClientEncoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.EncoderException;
 import io.netty5.handler.codec.MessageToByteEncoder;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5CommandRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5CommandRequestDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5CommandResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5CommandResponseDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5InitialRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5InitialRequestDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5InitialResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5InitialResponseDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5PasswordAuthRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5PasswordAuthRequestDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5PasswordAuthResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5PasswordAuthResponseDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.DecoderException;

--- a/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5ServerEncoder.java
+++ b/codec-socks/src/main/java/io/netty/contrib/handler/codec/socksx/v5/Socks5ServerEncoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.EncoderException;
 import io.netty5.handler.codec.MessageToByteEncoder;

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/NativeImageHandlerMetadataTest.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/NativeImageHandlerMetadataTest.java
@@ -23,7 +23,7 @@ public class NativeImageHandlerMetadataTest {
     @Test
     public void collectAndCompareMetadata() {
         ChannelHandlerMetadataUtil.generateMetadata(
-                "src/main/resources/META-INF/native-image/io.netty.contrib/netty-codec-socks/reflect-config.json",
+                "io.netty.contrib/netty-codec-socks/reflect-config.json",
                 "io.netty.contrib.handler.codec");
     }
 

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksAuthRequestDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksAuthRequestDecoderTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
 

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCmdRequestTest.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCmdRequestTest.java
@@ -15,14 +15,14 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 import java.net.IDN;
 import java.nio.CharBuffer;
 
-import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
+import static io.netty5.buffer.DefaultBufferAllocators.preferredAllocator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCmdResponseTest.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCmdResponseTest.java
@@ -15,14 +15,14 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 import java.net.IDN;
 import java.nio.CharBuffer;
 
-import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
+import static io.netty5.buffer.DefaultBufferAllocators.preferredAllocator;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCommonTestUtils.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socks/SocksCommonTestUtils.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socks;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 
 final class SocksCommonTestUtils {

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socksx/v5/DefaultSocks5CommandResponseTest.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socksx/v5/DefaultSocks5CommandResponseTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;

--- a/codec-socks/src/test/java/io/netty/contrib/handler/codec/socksx/v5/Socks5CommonTestUtils.java
+++ b/codec-socks/src/test/java/io/netty/contrib/handler/codec/socksx/v5/Socks5CommonTestUtils.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.socksx.v5;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 
 final class Socks5CommonTestUtils {

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/HttpProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/HttpProxyHandlerTest.java
@@ -48,7 +48,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
+import static io.netty5.buffer.DefaultBufferAllocators.preferredAllocator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/HttpProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/HttpProxyServer.java
@@ -38,7 +38,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 import static io.netty5.buffer.BufferUtil.writeAscii;
-import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
+import static io.netty5.buffer.DefaultBufferAllocators.preferredAllocator;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class HttpProxyServer extends ProxyServer {

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/NativeImageHandlerMetadataTest.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/NativeImageHandlerMetadataTest.java
@@ -23,7 +23,7 @@ package io.netty.contrib.handler.proxy;
      @Test
      public void collectAndCompareMetadata() {
          ChannelHandlerMetadataUtil.generateMetadata(
-                 "src/main/resources/META-INF/native-image/io.netty.contrib/netty-handler-proxy/reflect-config.json",
+                 "io.netty.contrib/netty-handler-proxy/reflect-config.json",
                  "io.netty.contrib.handler.proxy");
      }
 

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyHandlerTest.java
@@ -16,7 +16,7 @@
 package io.netty.contrib.handler.proxy;
 
 import io.netty5.bootstrap.Bootstrap;
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
@@ -63,7 +63,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import static io.netty5.buffer.BufferUtil.writeAscii;
-import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
+import static io.netty5.buffer.DefaultBufferAllocators.preferredAllocator;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyServer.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.proxy;
 
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelFutureListeners;
 import io.netty5.channel.ChannelHandler;


### PR DESCRIPTION
Motivation:
- Buffer API package was changed from `io.netty5.buffer.api` to `io.netty5.buffer` https://github.com/netty/netty/pull/12792
- Small enhancement was introduced to `ChannelHandlerMetadataUtil` https://github.com/netty/netty/pull/12786

Modification:
- Adapt to the changed package for Buffer API
- Adapt to the change in `ChannelHandlerMetadataUtil`

Result:
Project build is green again