### PR TITLE
Connect without password if server returns NO_AUTH when using Socks5

### DIFF
--- a/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/Socks5ProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/Socks5ProxyHandler.java
@@ -129,15 +129,15 @@ public final class Socks5ProxyHandler extends ProxyHandler {
         if (response instanceof Socks5InitialResponse) {
             Socks5InitialResponse res = (Socks5InitialResponse) response;
             Socks5AuthMethod authMethod = socksAuthMethod();
-
-            if (res.authMethod() != Socks5AuthMethod.NO_AUTH && res.authMethod() != authMethod) {
+            Socks5AuthMethod resAuthMethod = res.authMethod();
+            if (resAuthMethod != Socks5AuthMethod.NO_AUTH && resAuthMethod != authMethod) {
                 // Server did not allow unauthenticated access nor accept the requested authentication scheme.
                 throw new ProxyConnectException(exceptionMessage("unexpected authMethod: " + res.authMethod()));
             }
 
-            if (authMethod == Socks5AuthMethod.NO_AUTH) {
+            if (resAuthMethod == Socks5AuthMethod.NO_AUTH) {
                 sendConnectCommand(ctx);
-            } else if (authMethod == Socks5AuthMethod.PASSWORD) {
+            } else if (resAuthMethod == Socks5AuthMethod.PASSWORD) {
                 // In case of password authentication, send an authentication request.
                 ctx.pipeline().replace(decoderName, decoderName, new Socks5PasswordAuthResponseDecoder());
                 sendToProxyServer(new DefaultSocks5PasswordAuthRequest(
@@ -146,8 +146,6 @@ public final class Socks5ProxyHandler extends ProxyHandler {
                 // Should never reach here.
                 throw new Error();
             }
-
-            return false;
         }
 
         if (response instanceof Socks5PasswordAuthResponse) {

--- a/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/contrib/handler/proxy/ProxyHandlerTest.java
@@ -324,6 +324,12 @@ public class ProxyHandlerTest {
                         new Socks5ProxyHandler(anonSocks5Proxy.address())),
 
                 new SuccessTestItem(
+                        "SOCKS5: successful connection to anonymous server, AUTO_READ on",
+                        DESTINATION,
+                        true,
+                        new Socks5ProxyHandler(anonSocks5Proxy.address(), USERNAME, PASSWORD)),
+
+                new SuccessTestItem(
                         "Anonymous SOCKS5: successful connection, AUTO_READ off",
                         DESTINATION,
                         false,


### PR DESCRIPTION
Motivation:

When the server response with NO_AUTH we should just connect directly and not use a password at all in all cases

Modifications:

- Connect without password if the server tells jus to do so.
- Add unit test

Result:

Port over https://github.com/netty/netty/commit/34047463cf3a51fbbf071e8acd57c99cd4b333c4