### PR TITLE
Add javadoc for `ProxyHandler` and its implementations

### DIFF
--- a/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/HttpProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/HttpProxyHandler.java
@@ -42,6 +42,15 @@ import java.util.Base64;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Handler that establishes a blind forwarding proxy tunnel using
+ * <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.6">HTTP/1.1 CONNECT</a> request. It can be used to
+ * establish plaintext or secure tunnels.
+ * <p>
+ * HTTP users who need to connect to a
+ * <a href="https://datatracker.ietf.org/doc/html/rfc7230#page-10">message-forwarding HTTP proxy agent</a> instead of a
+ * tunneling proxy should not use this handler.
+ */
 public final class HttpProxyHandler extends ProxyHandler {
 
     private static final String PROTOCOL = "http";

--- a/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/ProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/ProxyHandler.java
@@ -35,6 +35,9 @@ import java.util.concurrent.TimeUnit;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * A common abstraction for protocols that establish blind forwarding proxy tunnels.
+ */
 public abstract class ProxyHandler implements ChannelHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(ProxyHandler.class);

--- a/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/Socks4ProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/Socks4ProxyHandler.java
@@ -27,6 +27,10 @@ import io.netty.contrib.handler.codec.socksx.v4.Socks4CommandType;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
+/**
+ * Handler that establishes a blind forwarding proxy tunnel using
+ * <a href="https://www.openssh.com/txt/socks4.protocol">SOCKS4</a> protocol.
+ */
 public final class Socks4ProxyHandler extends ProxyHandler {
 
     private static final String PROTOCOL = "socks4";

--- a/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/Socks5ProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/Socks5ProxyHandler.java
@@ -41,6 +41,10 @@ import java.net.SocketAddress;
 import java.util.Arrays;
 import java.util.Collections;
 
+/**
+ * Handler that establishes a blind forwarding proxy tunnel using
+ * <a href="https://www.rfc-editor.org/rfc/rfc1928">SOCKS Protocol Version 5</a>.
+ */
 public final class Socks5ProxyHandler extends ProxyHandler {
 
     private static final String PROTOCOL = "socks5";


### PR DESCRIPTION
Motivation:

Clarify purpose of `ProxyHandler`, `HttpProxyHandler`, `Socks4ProxyHandler`, and `Socks5ProxyHandler`.

Cherry-pick of https://github.com/netty/netty/pull/13638 from 4.1