### PR TITLE
Adapt to Netty Http header validation

### DIFF
--- a/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/HttpProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/contrib/handler/proxy/HttpProxyHandler.java
@@ -24,6 +24,7 @@ import io.netty5.handler.codec.http.DefaultFullHttpRequest;
 import io.netty5.handler.codec.http.FullHttpRequest;
 import io.netty5.handler.codec.http.HttpClientCodec;
 import io.netty5.handler.codec.http.HttpHeaderNames;
+import io.netty5.handler.codec.http.headers.DefaultHttpHeadersFactory;
 import io.netty5.handler.codec.http.headers.HttpHeaders;
 import io.netty5.handler.codec.http.HttpMethod;
 import io.netty5.handler.codec.http.HttpResponse;
@@ -31,6 +32,7 @@ import io.netty5.handler.codec.http.HttpResponseStatus;
 import io.netty5.handler.codec.http.HttpUtil;
 import io.netty5.handler.codec.http.HttpVersion;
 import io.netty5.handler.codec.http.LastHttpContent;
+import io.netty5.handler.codec.http.headers.HttpHeadersFactory;
 import io.netty5.util.AsciiString;
 import io.netty5.util.concurrent.Future;
 
@@ -159,10 +161,13 @@ public final class HttpProxyHandler extends ProxyHandler {
                 hostString :
                 url;
 
+        HttpHeadersFactory httpHeadersFactory = DefaultHttpHeadersFactory.headersFactory().withNameValidation(false).withValueValidation(false);
+        HttpHeadersFactory httpTrailersFactory = DefaultHttpHeadersFactory.trailersFactory().withNameValidation(false).withValueValidation(false);
+
         FullHttpRequest req = new DefaultFullHttpRequest(
                 HttpVersion.HTTP_1_1, HttpMethod.CONNECT,
                 url,
-                ctx.bufferAllocator().allocate(0), false);
+                ctx.bufferAllocator().allocate(0), httpHeadersFactory, httpTrailersFactory);
 
         req.headers().set(HttpHeaderNames.HOST, hostHeader);
 


### PR DESCRIPTION
Motivation:
The project doesn't build and needs to be adjusted, so it can begin using the new API introduced with the PR https://github.com/netty/netty/pull/13712.

Modifications
Use the new `DefaultFullHttpRequest` constructor in `HttpProxyHandler`.

Result
The project builds.